### PR TITLE
Day35: 'Merge Two Binary Trees' solution

### DIFF
--- a/DataStructures/BinaryTree/Day35/Day35.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/Day35/Day35.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1323155527D5FAC500EF6206 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1323155427D5FAC500EF6206 /* Assets.xcassets */; };
 		1323155827D5FAC500EF6206 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1323155627D5FAC500EF6206 /* LaunchScreen.storyboard */; };
 		1323156027D5FAED00EF6206 /* ViewController+Problem1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1323155F27D5FAEC00EF6206 /* ViewController+Problem1.swift */; };
+		1357CC6327D6870C00A29264 /* ViewController+Problem2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1357CC6227D6870C00A29264 /* ViewController+Problem2.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		1323155727D5FAC500EF6206 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1323155927D5FAC500EF6206 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1323155F27D5FAEC00EF6206 /* ViewController+Problem1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem1.swift"; sourceTree = "<group>"; };
+		1357CC6227D6870C00A29264 /* ViewController+Problem2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem2.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				1323154D27D5FAC300EF6206 /* SceneDelegate.swift */,
 				1323154F27D5FAC300EF6206 /* ViewController.swift */,
 				1323155F27D5FAEC00EF6206 /* ViewController+Problem1.swift */,
+				1357CC6227D6870C00A29264 /* ViewController+Problem2.swift */,
 				1323155127D5FAC300EF6206 /* Main.storyboard */,
 				1323155427D5FAC500EF6206 /* Assets.xcassets */,
 				1323155627D5FAC500EF6206 /* LaunchScreen.storyboard */,
@@ -144,6 +147,7 @@
 				1323156027D5FAED00EF6206 /* ViewController+Problem1.swift in Sources */,
 				1323155027D5FAC300EF6206 /* ViewController.swift in Sources */,
 				1323154C27D5FAC300EF6206 /* AppDelegate.swift in Sources */,
+				1357CC6327D6870C00A29264 /* ViewController+Problem2.swift in Sources */,
 				1323154E27D5FAC300EF6206 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DataStructures/BinaryTree/Day35/Day35/ViewController+Problem2.swift
+++ b/DataStructures/BinaryTree/Day35/Day35/ViewController+Problem2.swift
@@ -1,0 +1,64 @@
+//
+//  ViewController+Problem2.swift
+//  Day35
+//
+//  Created by Manish Rathi on 07/03/2022.
+//
+
+import Foundation
+
+/*
+ https://leetcode.com/problems/merge-two-binary-trees/
+ 617. Merge Two Binary Trees
+
+ You are given two binary trees root1 and root2.
+
+ Imagine that when you put one of them to cover the other, some nodes of the two trees are overlapped while the others are not. You need to merge the two trees into a new binary tree. The merge rule is that if two nodes overlap, then sum node values up as the new value of the merged node. Otherwise, the NOT null node will be used as the node of the new tree.
+
+ Return the merged tree.
+
+ Note: The merging process must start from the root nodes of both trees.
+
+ Example 1:
+
+ Input: root1 = [1,3,2,5], root2 = [2,1,3,null,4,null,7]
+ Output: [3,4,5,5,4,null,7]
+
+ Example 2:
+
+ Input: root1 = [1], root2 = [1,2]
+ Output: [2,2]
+ */
+
+extension ViewController {
+    func solve2() {
+        print("Setting up the inputs!")
+
+        let root1 = TreeNode(1)
+        root1.left = TreeNode(3)
+        root1.right = TreeNode(2)
+        root1.left?.left = TreeNode(5)
+
+        let root2 = TreeNode(2)
+        root2.left = TreeNode(1)
+        root2.right = TreeNode(3)
+        root2.left?.right = TreeNode(4)
+        root2.right?.right = TreeNode(7)
+
+        let mergeTree = mergeTrees(root1, root2)
+        print("MergeTree: \(mergeTree ?? TreeNode(0))")
+    }
+
+    private func mergeTrees(_ root1: TreeNode?, _ root2: TreeNode?) -> TreeNode? {
+        if root1 == nil && root2 == nil { return nil }
+
+        if root1 == nil { return root2 }
+        if root2 == nil { return root1 }
+
+
+        let leftMerge = mergeTrees(root1?.left, root2?.left)
+        let rightMerge = mergeTrees(root1?.right, root2?.right)
+
+        return TreeNode(root1!.val + root2!.val, leftMerge, rightMerge)
+    }
+}

--- a/DataStructures/BinaryTree/Day35/Day35/ViewController.swift
+++ b/DataStructures/BinaryTree/Day35/Day35/ViewController.swift
@@ -14,6 +14,9 @@ class ViewController: UIViewController {
 
         print("Problem 'Range Sum of BST' solution:\n\n")
         solve()
+
+        print("Problem 'Merge Two Binary Trees' solution:\n\n")
+        solve2()
     }
 }
 


### PR DESCRIPTION
 https://leetcode.com/problems/merge-two-binary-trees/
 617. Merge Two Binary Trees

 You are given two binary trees root1 and root2.

 Imagine that when you put one of them to cover the other, some nodes of the two trees are overlapped while the others are not. You need to merge the two trees into a new binary tree. The merge rule is that if two nodes overlap, then sum node values up as the new value of the merged node. Otherwise, the NOT null node will be used as the node of the new tree.

 Return the merged tree.

 Note: The merging process must start from the root nodes of both trees.

 Example 1:

 Input: root1 = [1,3,2,5], root2 = [2,1,3,null,4,null,7]
 Output: [3,4,5,5,4,null,7]

 Example 2:

 Input: root1 = [1], root2 = [1,2]
 Output: [2,2]