### PR TITLE
Day36: 'Increasing Order Search Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1357CC7A27D741F500A29264 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1357CC7927D741F500A29264 /* Assets.xcassets */; };
 		1357CC7D27D741F500A29264 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */; };
 		1357CC8527D7427500A29264 /* TreeNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1357CC8427D7427500A29264 /* TreeNode.swift */; };
+		13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		1357CC7C27D741F500A29264 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1357CC7E27D741F500A29264 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1357CC8427D7427500A29264 /* TreeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeNode.swift; sourceTree = "<group>"; };
+		13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem1.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				1357CC7227D741F200A29264 /* SceneDelegate.swift */,
 				1357CC7427D741F200A29264 /* ViewController.swift */,
 				1357CC8427D7427500A29264 /* TreeNode.swift */,
+				13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -143,6 +146,7 @@
 			files = (
 				1357CC7527D741F200A29264 /* ViewController.swift in Sources */,
 				1357CC7127D741F200A29264 /* AppDelegate.swift in Sources */,
+				13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */,
 				1357CC7327D741F200A29264 /* SceneDelegate.swift in Sources */,
 				1357CC8527D7427500A29264 /* TreeNode.swift in Sources */,
 			);

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem1.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem1.swift
@@ -1,0 +1,68 @@
+//
+//  ViewController+Problem1.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 08/03/2022.
+//
+
+import Foundation
+/*
+ 897. Increasing Order Search Tree
+ https://leetcode.com/problems/increasing-order-search-tree/
+
+ Given the root of a binary search tree, rearrange the tree in in-order so that the leftmost node in the tree is now the root of the tree, and every node has no left child and only one right child.
+ */
+
+class Queue {
+    private var array: [Int] = []
+
+    var isEmpty: Bool { return array.isEmpty }
+
+    func enQueue(_ value: Int) {
+        array.append(value)
+    }
+
+    func deQueue() -> Int? {
+        if isEmpty { return nil }
+
+        return array.removeFirst()
+    }
+}
+
+extension ViewController {
+    func solve1() {
+        print("Setting up Problem1 input!")
+        let root = TreeNode(5)
+        root.left = TreeNode(1)
+        root.right = TreeNode(7)
+
+        let output = increasingBST(root)
+        print("Output: \(output)")
+    }
+
+    func increasingBST(_ root: TreeNode?) -> TreeNode? {
+        if root == nil { return nil }
+
+        let queue = Queue()
+        getAllBSTNodes(root, queue: queue)
+
+        var outputNode: TreeNode? = TreeNode(-1)
+        let outputRootNode = outputNode
+
+        while queue.isEmpty == false {
+            let newNode = TreeNode(queue.deQueue()!)
+            outputNode?.right = newNode
+            outputNode = outputNode?.right
+        }
+
+        return outputRootNode?.right
+    }
+
+    func getAllBSTNodes(_ root: TreeNode?, queue: Queue) {
+        if root == nil { return }
+
+        getAllBSTNodes(root?.left, queue: queue)
+        queue.enQueue(root!.val)
+        getAllBSTNodes(root?.right, queue: queue)
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -12,6 +12,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+
+        solve1()
     }
 
 


### PR DESCRIPTION
 897. Increasing Order Search Tree
 https://leetcode.com/problems/increasing-order-search-tree/

 Given the root of a binary search tree, rearrange the tree in in-order so that the leftmost node in the tree is now the root of the tree, and every node has no left child and only one right child.