### PR TITLE
Day37: 'Maximum Depth of Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1357CC7A27D741F500A29264 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1357CC7927D741F500A29264 /* Assets.xcassets */; };
 		1357CC7D27D741F500A29264 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */; };
 		1357CC8527D7427500A29264 /* TreeNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1357CC8427D7427500A29264 /* TreeNode.swift */; };
+		138928EC27D936E3003B5855 /* ViewController+Problem4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138928EB27D936E3003B5855 /* ViewController+Problem4.swift */; };
 		13A3675427D7DBE70098E2EA /* ViewController+Problem2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3675327D7DBE70098E2EA /* ViewController+Problem2.swift */; };
 		13A3675627D86E120098E2EA /* ViewController+Problem3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3675527D86E120098E2EA /* ViewController+Problem3.swift */; };
 		13A3675827D8A38C0098E2EA /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3675727D8A38C0098E2EA /* Queue.swift */; };
@@ -30,6 +31,7 @@
 		1357CC7C27D741F500A29264 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1357CC7E27D741F500A29264 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1357CC8427D7427500A29264 /* TreeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeNode.swift; sourceTree = "<group>"; };
+		138928EB27D936E3003B5855 /* ViewController+Problem4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem4.swift"; sourceTree = "<group>"; };
 		13A3675327D7DBE70098E2EA /* ViewController+Problem2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem2.swift"; sourceTree = "<group>"; };
 		13A3675527D86E120098E2EA /* ViewController+Problem3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem3.swift"; sourceTree = "<group>"; };
 		13A3675727D8A38C0098E2EA /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */,
 				13A3675327D7DBE70098E2EA /* ViewController+Problem2.swift */,
 				13A3675527D86E120098E2EA /* ViewController+Problem3.swift */,
+				138928EB27D936E3003B5855 /* ViewController+Problem4.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -157,6 +160,7 @@
 				13A3675627D86E120098E2EA /* ViewController+Problem3.swift in Sources */,
 				1357CC7127D741F200A29264 /* AppDelegate.swift in Sources */,
 				13A3675827D8A38C0098E2EA /* Queue.swift in Sources */,
+				138928EC27D936E3003B5855 /* ViewController+Problem4.swift in Sources */,
 				13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */,
 				13A3675427D7DBE70098E2EA /* ViewController+Problem2.swift in Sources */,
 				1357CC7327D741F200A29264 /* SceneDelegate.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem4.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem4.swift
@@ -1,0 +1,61 @@
+//
+//  ViewController+Problem4.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 09/03/2022.
+//
+
+import Foundation
+/*
+ 104. Maximum Depth of Binary Tree
+ https://leetcode.com/problems/maximum-depth-of-binary-tree/
+
+ Given the root of a binary tree, return its maximum depth.
+ A binary tree's maximum depth is the number of nodes along the longest path from the root node down to the farthest leaf node.
+
+ Example 1:
+
+ Input: root = [3,9,20,null,null,15,7]
+ Output: 3
+ Example 2:
+
+ Input: root = [1,null,2]
+ Output: 2
+ */
+
+extension ViewController {
+    func solve4() {
+        print("Setting up Problem4 input!")
+        let root = TreeNode(3)
+        root.left = TreeNode(9)
+        root.right = TreeNode(20)
+        root.right?.left = TreeNode(15)
+        root.right?.right = TreeNode(7)
+
+        let output = Solution().maxDepth(root)
+        print("Output: \(output as Any)")
+    }
+}
+
+fileprivate class Solution {
+    var maxDepth = 0
+
+    func maxDepth(_ root: TreeNode?) -> Int {
+        findMaxDepth(root, 0)
+
+        return maxDepth
+    }
+
+    private func findMaxDepth(_ root: TreeNode?, _ currentDepth: Int) {
+        if root == nil { return }
+
+        let newCurrentDepth = currentDepth + 1
+
+        if root?.left == nil && root?.right == nil {
+            maxDepth = max(maxDepth, newCurrentDepth)
+        } else {
+            findMaxDepth(root?.left, newCurrentDepth)
+            findMaxDepth(root?.right, newCurrentDepth)
+        }
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -16,5 +16,6 @@ class ViewController: UIViewController {
         solve1()
         solve2()
         solve3()
+        solve4()
     }
 }

--- a/README.md
+++ b/README.md
@@ -171,3 +171,4 @@ Day36: 08-March-2022
 
 Day37: 09-March-2022
 - [x] [LeetCode-1022: Sum of Root To Leaf Binary Numbers](https://leetcode.com/problems/sum-of-root-to-leaf-binary-numbers/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem3.swift)
+- [x] [LeetCode-104: Maximum Depth of Binary Tree](https://leetcode.com/problems/maximum-depth-of-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem4.swift)


### PR DESCRIPTION
 104. Maximum Depth of Binary Tree
 https://leetcode.com/problems/maximum-depth-of-binary-tree/

 Given the root of a binary tree, return its maximum depth.
 A binary tree's maximum depth is the number of nodes along the longest path from the root node down to the farthest leaf node.

 Example 1:
 Input: root = [3,9,20,null,null,15,7]
 Output: 3

 Example 2:
 Input: root = [1,null,2]
 Output: 2