### PR TITLE
Day40: 'Convert Sorted Array to Binary Search Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		13A3675827D8A38C0098E2EA /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3675727D8A38C0098E2EA /* Queue.swift */; };
 		13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */; };
 		13B00B1827DBAC400061E451 /* ViewController+Problem8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B00B1727DBAC400061E451 /* ViewController+Problem8.swift */; };
+		13C1CBEA27DC8ECF008AF400 /* ViewController+Problem9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBE927DC8ECF008AF400 /* ViewController+Problem9.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		13A3675727D8A38C0098E2EA /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		13A5F2DD27D7481D00515002 /* ViewController+Problem1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem1.swift"; sourceTree = "<group>"; };
 		13B00B1727DBAC400061E451 /* ViewController+Problem8.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem8.swift"; sourceTree = "<group>"; };
+		13C1CBE927DC8ECF008AF400 /* ViewController+Problem9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem9.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +91,7 @@
 				1389293727DA8691003B5855 /* ViewController+Problem6.swift */,
 				1389293927DB4472003B5855 /* ViewController+Problem7.swift */,
 				13B00B1727DBAC400061E451 /* ViewController+Problem8.swift */,
+				13C1CBE927DC8ECF008AF400 /* ViewController+Problem9.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -170,6 +173,7 @@
 			files = (
 				1357CC7527D741F200A29264 /* ViewController.swift in Sources */,
 				13A3675627D86E120098E2EA /* ViewController+Problem3.swift in Sources */,
+				13C1CBEA27DC8ECF008AF400 /* ViewController+Problem9.swift in Sources */,
 				1389293A27DB4472003B5855 /* ViewController+Problem7.swift in Sources */,
 				1357CC7127D741F200A29264 /* AppDelegate.swift in Sources */,
 				13A3675827D8A38C0098E2EA /* Queue.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem9.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem9.swift
@@ -1,0 +1,52 @@
+//
+//  ViewController+Problem9.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 12/03/2022.
+//
+
+import Foundation
+/*
+ 108. Convert Sorted Array to Binary Search Tree
+ https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/
+
+ Given an integer array nums where the elements are sorted in ascending order, convert it to a height-balanced binary search tree.
+ A height-balanced binary tree is a binary tree in which the depth of the two subtrees of every node never differs by more than one.
+
+ Example 1:
+ Input: nums = [-10,-3,0,5,9]
+ Output: [0,-3,9,-10,null,5]
+ Explanation: [0,-10,5,null,-3,null,9] is also accepted:
+
+ Example 2:
+ Input: nums = [1,3]
+ Output: [3,1]
+ Explanation: [1,null,3] and [3,1] are both height-balanced BSTs.
+ */
+
+extension ViewController {
+    func solve9() {
+        print("Setting up Problem9 input!")
+        let input = [5, 10, 15, 20]
+
+        let output = Solution().sortedArrayToBST(input)
+        print("Output: \(String(describing: output?.inorderTraversal))")
+    }
+}
+
+fileprivate class Solution {
+    func sortedArrayToBST(_ nums: [Int]) -> TreeNode? {
+        if nums.isEmpty { return nil }
+
+        let mid = nums.count / 2
+
+        let root = TreeNode(nums[mid])
+        let left = sortedArrayToBST(Array(nums[0..<mid]))
+        let right = sortedArrayToBST(Array(nums[mid+1..<nums.count]))
+
+        root.left = left
+        root.right = right
+
+        return root
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -21,5 +21,6 @@ class ViewController: UIViewController {
         solve6()
         solve7()
         solve8()
+        solve9()
     }
 }

--- a/README.md
+++ b/README.md
@@ -180,3 +180,6 @@ Day38: 10-March-2022
 Day39: 11-March-2022
 - [x] [LeetCode-965: Univalued Binary Tree](https://leetcode.com/problems/univalued-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem7.swift)
 - [x] [LeetCode-637: Average of Levels in Binary Tree](https://leetcode.com/problems/average-of-levels-in-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem8.swift)
+
+Day40: 12-March-2022
+- [x] [LeetCode-108: Convert Sorted Array to Binary Search Tree](https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem9.swift)


### PR DESCRIPTION
 108. Convert Sorted Array to Binary Search Tree
 https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/

 Given an integer array nums where the elements are sorted in ascending order, convert it to a height-balanced binary search tree.
 A height-balanced binary tree is a binary tree in which the depth of the two subtrees of every node never differs by more than one.

 Example 1:
 Input: nums = [-10,-3,0,5,9]
 Output: [0,-3,9,-10,null,5]
 Explanation: [0,-10,5,null,-3,null,9] is also accepted:

 Example 2:
 Input: nums = [1,3]
 Output: [3,1]
 Explanation: [1,null,3] and [3,1] are both height-balanced BSTs.