### PR TITLE
Day41: 'Construct String from Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		13C1CBF227DD1C53008AF400 /* ViewController+Problem13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF127DD1C53008AF400 /* ViewController+Problem13.swift */; };
 		13C1CBF427DD30AC008AF400 /* ViewController+Problem14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */; };
 		13C1CBF627DDD031008AF400 /* ViewController+Problem15.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */; };
+		13C1CBF827DE028D008AF400 /* ViewController+Problem16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,7 @@
 		13C1CBF127DD1C53008AF400 /* ViewController+Problem13.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem13.swift"; sourceTree = "<group>"; };
 		13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem14.swift"; sourceTree = "<group>"; };
 		13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem15.swift"; sourceTree = "<group>"; };
+		13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem16.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 				13C1CBF127DD1C53008AF400 /* ViewController+Problem13.swift */,
 				13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */,
 				13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */,
+				13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -189,6 +192,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				13C1CBF827DE028D008AF400 /* ViewController+Problem16.swift in Sources */,
 				1357CC7527D741F200A29264 /* ViewController.swift in Sources */,
 				13A3675627D86E120098E2EA /* ViewController+Problem3.swift in Sources */,
 				13C1CBEA27DC8ECF008AF400 /* ViewController+Problem9.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem16.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem16.swift
@@ -1,0 +1,57 @@
+//
+//  ViewController+Problem16.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 13/03/2022.
+//
+
+import Foundation
+/*
+ 606. Construct String from Binary Tree
+ https://leetcode.com/problems/construct-string-from-binary-tree/
+ Given the root of a binary tree, construct a string consisting of parenthesis and integers from a binary tree with the preorder traversal way, and return it.
+ Omit all the empty parenthesis pairs that do not affect the one-to-one mapping relationship between the string and the original binary tree.
+
+ Example 1:
+ Input: root = [1,2,3,4]
+ Output: "1(2(4))(3)"
+ Explanation: Originally, it needs to be "1(2(4)())(3()())", but you need to omit all the unnecessary empty parenthesis pairs. And it will be "1(2(4))(3)"
+
+ Example 2:
+ Input: root = [1,2,3,null,4]
+ Output: "1(2()(4))(3)"
+ Explanation: Almost the same as the first example, except we cannot omit the first parenthesis pair to break the one-to-one mapping relationship between the input and the output.
+ */
+
+extension ViewController {
+    func solve16() {
+        print("Setting up Problem16 input!")
+        let root = TreeNode(1)
+        root.left = TreeNode(2)
+        root.right = TreeNode(3)
+        root.left?.right = TreeNode(4)
+
+        let output = Solution().tree2str(root)
+        print("Output: \(output)")
+    }
+}
+
+fileprivate class Solution {
+    func tree2str(_ root: TreeNode?) -> String {
+        guard let root = root else { return "" }
+
+        if root.left == nil && root.right == nil {
+            return "\(root.val)"
+        }
+
+        let leftTree2str = tree2str(root.left)
+
+        if root.left != nil && root.right == nil {
+            return "\(root.val)" + "(" + leftTree2str + ")"
+        }
+
+        let rightTree2str = tree2str(root.right)
+
+        return "\(root.val)" + "(" + leftTree2str + ")"  + "(" + rightTree2str + ")"
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -28,5 +28,6 @@ class ViewController: UIViewController {
         solve13()
         solve14()
         solve15()
+        solve16()
     }
 }

--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ Day40: 12-March-2022
 
 Day40: 13-March-2022
 - [x] [LeetCode-257: Binary Tree Paths](https://leetcode.com/problems/binary-tree-paths/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem15.swift)
+- [x] [LeetCode-606: Construct String from Binary Tree](https://leetcode.com/problems/construct-string-from-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem16.swift)


### PR DESCRIPTION
 606. Construct String from Binary Tree
 https://leetcode.com/problems/construct-string-from-binary-tree/
 Given the root of a binary tree, construct a string consisting of parenthesis and integers from a binary tree with the preorder traversal way, and return it.
 Omit all the empty parenthesis pairs that do not affect the one-to-one mapping relationship between the string and the original binary tree.

 Example 1:
 Input: root = [1,2,3,4]
 Output: "1(2(4))(3)"
 Explanation: Originally, it needs to be "1(2(4)())(3()())", but you need to omit all the unnecessary empty parenthesis pairs. And it will be "1(2(4))(3)"

 Example 2:
 Input: root = [1,2,3,null,4]
 Output: "1(2()(4))(3)"
 Explanation: Almost the same as the first example, except we cannot omit the first parenthesis pair to break the one-to-one mapping relationship between the input and the output.