### PR TITLE
Day41: 'Lowest Common Ancestor of a Binary Search Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		13C1CBF427DD30AC008AF400 /* ViewController+Problem14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */; };
 		13C1CBF627DDD031008AF400 /* ViewController+Problem15.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */; };
 		13C1CBF827DE028D008AF400 /* ViewController+Problem16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */; };
+		13C1CBFA27DE1059008AF400 /* ViewController+Problem17.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CBF927DE1059008AF400 /* ViewController+Problem17.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +61,7 @@
 		13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem14.swift"; sourceTree = "<group>"; };
 		13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem15.swift"; sourceTree = "<group>"; };
 		13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem16.swift"; sourceTree = "<group>"; };
+		13C1CBF927DE1059008AF400 /* ViewController+Problem17.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem17.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 				13C1CBF327DD30AC008AF400 /* ViewController+Problem14.swift */,
 				13C1CBF527DDD031008AF400 /* ViewController+Problem15.swift */,
 				13C1CBF727DE028D008AF400 /* ViewController+Problem16.swift */,
+				13C1CBF927DE1059008AF400 /* ViewController+Problem17.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -208,6 +211,7 @@
 				13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */,
 				13A3675427D7DBE70098E2EA /* ViewController+Problem2.swift in Sources */,
 				1357CC7327D741F200A29264 /* SceneDelegate.swift in Sources */,
+				13C1CBFA27DE1059008AF400 /* ViewController+Problem17.swift in Sources */,
 				138928EE27D9EF1D003B5855 /* ViewController+Problem5.swift in Sources */,
 				13C1CBF027DD1003008AF400 /* ViewController+Problem12.swift in Sources */,
 				1357CC8527D7427500A29264 /* TreeNode.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem17.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem17.swift
@@ -1,0 +1,60 @@
+//
+//  ViewController+Problem17.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 13/03/2022.
+//
+
+import Foundation
+/*
+ 235. Lowest Common Ancestor of a Binary Search Tree
+ https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-search-tree/
+ Given a binary search tree (BST), find the lowest common ancestor (LCA) of two given nodes in the BST.
+ According to the definition of LCA on Wikipedia: “The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has both p and q as descendants (where we allow a node to be a descendant of itself).”
+
+ Example 1:
+ Input: root = [6,2,8,0,4,7,9,null,null,3,5], p = 2, q = 8
+ Output: 6
+ Explanation: The LCA of nodes 2 and 8 is 6.
+
+ Example 2:
+ Input: root = [6,2,8,0,4,7,9,null,null,3,5], p = 2, q = 4
+ Output: 2
+ Explanation: The LCA of nodes 2 and 4 is 2, since a node can be a descendant of itself according to the LCA definition.
+
+ Example 3:
+ Input: root = [2,1], p = 2, q = 1
+ Output: 2
+ */
+
+extension ViewController {
+    func solve17() {
+        print("Setting up Problem17 input!")
+        let root = TreeNode(6)
+        root.left = TreeNode(2)
+        root.right = TreeNode(8)
+        root.left?.left = TreeNode(0)
+        root.left?.right = TreeNode(4)
+        root.left?.right?.left = TreeNode(3)
+        root.left?.right?.right = TreeNode(5)
+        root.right?.left = TreeNode(7)
+        root.right?.right = TreeNode(9)
+
+        let output = Solution().lowestCommonAncestor(root, root.left, root.right)
+        print("Output: \(output!.val)")
+    }
+}
+
+fileprivate class Solution {
+    func lowestCommonAncestor(_ root: TreeNode?, _ p: TreeNode?, _ q: TreeNode?) -> TreeNode? {
+        guard let root = root, let p = p, let q = q else { return nil }
+
+        if root.val > p.val && root.val > q.val {
+            return lowestCommonAncestor(root.left, p, q)
+        } else if root.val < p.val && root.val < q.val {
+            return lowestCommonAncestor(root.right, p, q)
+        } else {
+            return root
+        }
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -29,5 +29,6 @@ class ViewController: UIViewController {
         solve14()
         solve15()
         solve16()
+        solve17()
     }
 }

--- a/README.md
+++ b/README.md
@@ -192,3 +192,4 @@ Day40: 12-March-2022
 Day40: 13-March-2022
 - [x] [LeetCode-257: Binary Tree Paths](https://leetcode.com/problems/binary-tree-paths/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem15.swift)
 - [x] [LeetCode-606: Construct String from Binary Tree](https://leetcode.com/problems/construct-string-from-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem16.swift)
+- [x] [LeetCode-235: Lowest Common Ancestor of a Binary Search Tree](https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-search-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem17.swift)


### PR DESCRIPTION
 235. Lowest Common Ancestor of a Binary Search Tree
 https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-search-tree/
 Given a binary search tree (BST), find the lowest common ancestor (LCA) of two given nodes in the BST.
 According to the definition of LCA on Wikipedia: “The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has both p and q as descendants (where we allow a node to be a descendant of itself).”

 Example 1:
 Input: root = [6,2,8,0,4,7,9,null,null,3,5], p = 2, q = 8
 Output: 6
 Explanation: The LCA of nodes 2 and 8 is 6.

 Example 2:
 Input: root = [6,2,8,0,4,7,9,null,null,3,5], p = 2, q = 4
 Output: 2
 Explanation: The LCA of nodes 2 and 4 is 2, since a node can be a descendant of itself according to the LCA definition.

 Example 3:
 Input: root = [2,1], p = 2, q = 1
 Output: 2