### PR TITLE
Day43: 'Find Mode in Binary Search Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		13C1CC1427DFC56A008AF400 /* ViewController+Problem22.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC1327DFC56A008AF400 /* ViewController+Problem22.swift */; };
 		13C1CC1627E08DC1008AF400 /* ViewController+Problem23.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC1527E08DC1008AF400 /* ViewController+Problem23.swift */; };
 		13C1CC1827E0A614008AF400 /* ViewController+Problem24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */; };
+		13C1CC3127E0F448008AF400 /* ViewController+Problem25.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +77,7 @@
 		13C1CC1327DFC56A008AF400 /* ViewController+Problem22.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem22.swift"; sourceTree = "<group>"; };
 		13C1CC1527E08DC1008AF400 /* ViewController+Problem23.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem23.swift"; sourceTree = "<group>"; };
 		13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem24.swift"; sourceTree = "<group>"; };
+		13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem25.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +139,7 @@
 				13C1CC1327DFC56A008AF400 /* ViewController+Problem22.swift */,
 				13C1CC1527E08DC1008AF400 /* ViewController+Problem23.swift */,
 				13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */,
+				13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -223,6 +226,7 @@
 				13C1CC1227DFBBC7008AF400 /* ViewController+Problem21.swift in Sources */,
 				13C1CC1627E08DC1008AF400 /* ViewController+Problem23.swift in Sources */,
 				13C1CBEA27DC8ECF008AF400 /* ViewController+Problem9.swift in Sources */,
+				13C1CC3127E0F448008AF400 /* ViewController+Problem25.swift in Sources */,
 				1389293A27DB4472003B5855 /* ViewController+Problem7.swift in Sources */,
 				13C1CBF227DD1C53008AF400 /* ViewController+Problem13.swift in Sources */,
 				1357CC7127D741F200A29264 /* AppDelegate.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem25.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem25.swift
@@ -1,0 +1,83 @@
+//
+//  ViewController+Problem25.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 15/03/2022.
+//
+
+import Foundation
+/*
+ 501. Find Mode in Binary Search Tree
+ https://leetcode.com/problems/find-mode-in-binary-search-tree/
+ Given the root of a binary search tree (BST) with duplicates, return all the mode(s) (i.e., the most frequently occurred element) in it.
+ If the tree has more than one mode, return them in any order.
+
+ Assume a BST is defined as follows:
+ The left subtree of a node contains only nodes with keys less than or equal to the node's key.
+ The right subtree of a node contains only nodes with keys greater than or equal to the node's key.
+ Both the left and right subtrees must also be binary search trees.
+
+ Example 1:
+ Input: root = [1,null,2,2]
+ Output: [2]
+
+ Example 2:
+ Input: root = [0]
+ Output: [0]
+ */
+
+extension ViewController {
+    func solve25() {
+        print("Setting up Problem25 input!")
+        let root = TreeNode(1)
+        root.left = TreeNode(0)
+        root.right = TreeNode(1)
+        root.left?.left = TreeNode(0)
+        root.left?.right = TreeNode(0)
+        root.right?.left = TreeNode(1)
+        root.right?.right = TreeNode(1)
+        root.left?.left?.left = TreeNode(0)
+
+        let output = Solution().findMode(root)
+        print("Output: \(output)")
+    }
+}
+
+fileprivate class Solution {
+    private var nodeValueCounterMap: [Int : Int] = [:]
+    private var maximumCounter: Int = Int.min
+
+    func findMode(_ root: TreeNode?) -> [Int] {
+        guard let currentNode = root else { return [] }
+
+        findRecursiveMode(currentNode)
+
+        var outputResults: [Int] = []
+
+        for (key, value) in nodeValueCounterMap {
+            if value == maximumCounter { outputResults.append(key) }
+        }
+
+        return outputResults
+    }
+
+    private func findRecursiveMode(_ root: TreeNode?) {
+        guard let currentNode = root else { return }
+
+        let currentNodeValue = currentNode.val
+        let currentNodeCounter: Int
+
+        if let cacheCounter = nodeValueCounterMap[currentNodeValue] {
+            currentNodeCounter = cacheCounter + 1
+        } else {
+            currentNodeCounter = 0
+        }
+
+        nodeValueCounterMap[currentNodeValue] = currentNodeCounter
+
+        maximumCounter = max(maximumCounter, currentNodeCounter)
+
+        findRecursiveMode(currentNode.left)
+        findRecursiveMode(currentNode.right)
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -37,5 +37,6 @@ class ViewController: UIViewController {
         solve22()
         solve23()
         solve24()
+        solve25()
     }
 }

--- a/README.md
+++ b/README.md
@@ -204,3 +204,4 @@ Day42: 14-March-2022
 Day43: 15-March-2022
 - [x] [LeetCode-543: Diameter of Binary Tree](https://leetcode.com/problems/diameter-of-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem23.swift)
 - [x] [LeetCode-101: Symmetric Tree](https://leetcode.com/problems/symmetric-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem24.swift)
+- [x] [LeetCode-501: Find Mode in Binary Search Tree](https://leetcode.com/problems/find-mode-in-binary-search-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem25.swift)


### PR DESCRIPTION
 501. Find Mode in Binary Search Tree
 https://leetcode.com/problems/find-mode-in-binary-search-tree/
 Given the root of a binary search tree (BST) with duplicates, return all the mode(s) (i.e., the most frequently occurred element) in it.
 If the tree has more than one mode, return them in any order.

 Assume a BST is defined as follows:
 The left subtree of a node contains only nodes with keys less than or equal to the node's key.
 The right subtree of a node contains only nodes with keys greater than or equal to the node's key.
 Both the left and right subtrees must also be binary search trees.

 Example 1:
 Input: root = [1,null,2,2]
 Output: [2]

 Example 2:
 Input: root = [0]
 Output: [0]