### PR TITLE
Day43: 'Path Sum Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		13C1CC1827E0A614008AF400 /* ViewController+Problem24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */; };
 		13C1CC3127E0F448008AF400 /* ViewController+Problem25.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */; };
 		13C1CC3327E0FFD5008AF400 /* ViewController+Problem26.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC3227E0FFD5008AF400 /* ViewController+Problem26.swift */; };
+		13C1CC3527E107CA008AF400 /* ViewController+Problem27.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC3427E107CA008AF400 /* ViewController+Problem27.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -80,6 +81,7 @@
 		13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem24.swift"; sourceTree = "<group>"; };
 		13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem25.swift"; sourceTree = "<group>"; };
 		13C1CC3227E0FFD5008AF400 /* ViewController+Problem26.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem26.swift"; sourceTree = "<group>"; };
+		13C1CC3427E107CA008AF400 /* ViewController+Problem27.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem27.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +145,7 @@
 				13C1CC1727E0A614008AF400 /* ViewController+Problem24.swift */,
 				13C1CC3027E0F448008AF400 /* ViewController+Problem25.swift */,
 				13C1CC3227E0FFD5008AF400 /* ViewController+Problem26.swift */,
+				13C1CC3427E107CA008AF400 /* ViewController+Problem27.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -251,6 +254,7 @@
 				1357CC8527D7427500A29264 /* TreeNode.swift in Sources */,
 				13C1CBF627DDD031008AF400 /* ViewController+Problem15.swift in Sources */,
 				13C1CBFC27DE51F5008AF400 /* ViewController+Problem18.swift in Sources */,
+				13C1CC3527E107CA008AF400 /* ViewController+Problem27.swift in Sources */,
 				13C1CBFE27DF3B2F008AF400 /* ViewController+Problem19.swift in Sources */,
 				1389293827DA8691003B5855 /* ViewController+Problem6.swift in Sources */,
 			);

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem27.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem27.swift
@@ -1,0 +1,62 @@
+//
+//  ViewController+Problem27.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 15/03/2022.
+//
+
+import Foundation
+/*
+ 112. Path Sum
+ https://leetcode.com/problems/path-sum/
+ Given the root of a binary tree and an integer targetSum, return true if the tree has a root-to-leaf path such that adding up all the values along the path equals targetSum.
+ A leaf is a node with no children.
+
+ Example 1:
+ Input: root = [5,4,8,11,null,13,4,7,2,null,null,null,1], targetSum = 22
+ Output: true
+ Explanation: The root-to-leaf path with the target sum is shown.
+
+ Example 2:
+ Input: root = [1,2,3], targetSum = 5
+ Output: false
+ Explanation: There two root-to-leaf paths in the tree:
+ (1 --> 2): The sum is 3.
+ (1 --> 3): The sum is 4.
+ There is no root-to-leaf path with sum = 5.
+ */
+
+extension ViewController {
+    func solve27() {
+        print("Setting up Problem27 input!")
+        let root = TreeNode(1)
+        root.left = TreeNode(2)
+        root.right = TreeNode(3)
+
+        let output = Solution().hasPathSum(root, 5)
+        print("Output: \(output)")
+    }
+}
+
+fileprivate class Solution {
+    private var pathSumMap: [Int: Bool] = [:]
+
+    func hasPathSum(_ root: TreeNode?, _ targetSum: Int) -> Bool {
+        findAllPaths(root, 0)
+
+        return pathSumMap[targetSum] != nil
+    }
+
+    private func findAllPaths(_ root: TreeNode?, _ currentSum: Int) {
+        guard let currentNode = root else { return }
+
+        let newSum = currentSum + currentNode.val
+
+        if currentNode.left == nil && currentNode.right == nil {
+            pathSumMap[newSum] = true
+        }
+
+        findAllPaths(currentNode.left, newSum)
+        findAllPaths(currentNode.right, newSum)
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -39,5 +39,6 @@ class ViewController: UIViewController {
         solve24()
         solve25()
         solve26()
+        solve27()
     }
 }

--- a/README.md
+++ b/README.md
@@ -206,3 +206,4 @@ Day43: 15-March-2022
 - [x] [LeetCode-101: Symmetric Tree](https://leetcode.com/problems/symmetric-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem24.swift)
 - [x] [LeetCode-501: Find Mode in Binary Search Tree](https://leetcode.com/problems/find-mode-in-binary-search-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem25.swift)
 - [x] [LeetCode-110: Balanced Binary Tree](https://leetcode.com/problems/balanced-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem26.swift)
+- [x] [LeetCode-112: Path Sum](https://leetcode.com/problems/path-sum/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem27.swift)


### PR DESCRIPTION
 112. Path Sum
 https://leetcode.com/problems/path-sum/
 Given the root of a binary tree and an integer targetSum, return true if the tree has a root-to-leaf path such that adding up all the values along the path equals targetSum.
 A leaf is a node with no children.

 Example 1:
 Input: root = [5,4,8,11,null,13,4,7,2,null,null,null,1], targetSum = 22
 Output: true
 Explanation: The root-to-leaf path with the target sum is shown.

 Example 2:
 Input: root = [1,2,3], targetSum = 5
 Output: false
 Explanation: There two root-to-leaf paths in the tree:
 (1 --> 2): The sum is 3.
 (1 --> 3): The sum is 4.
 There is no root-to-leaf path with sum = 5.