### PR TITLE
Day46: 'Vertical Order Traversal of a Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		13C1CC7827E354E6008AF400 /* ViewController+Problem38.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC7727E354E6008AF400 /* ViewController+Problem38.swift */; };
 		13C1CC8A27E39971008AF400 /* ViewController+Problem39.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */; };
 		13C1CC8C27E3A46B008AF400 /* ViewController+Problem40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */; };
+		13C1CC8E27E3C759008AF400 /* ViewController+Problem41.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -108,6 +109,7 @@
 		13C1CC7727E354E6008AF400 /* ViewController+Problem38.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem38.swift"; sourceTree = "<group>"; };
 		13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem39.swift"; sourceTree = "<group>"; };
 		13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem40.swift"; sourceTree = "<group>"; };
+		13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem41.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,6 +187,7 @@
 				13C1CC7727E354E6008AF400 /* ViewController+Problem38.swift */,
 				13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */,
 				13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */,
+				13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -277,6 +280,7 @@
 				13C1CC1627E08DC1008AF400 /* ViewController+Problem23.swift in Sources */,
 				13C1CBEA27DC8ECF008AF400 /* ViewController+Problem9.swift in Sources */,
 				13C1CC3127E0F448008AF400 /* ViewController+Problem25.swift in Sources */,
+				13C1CC8E27E3C759008AF400 /* ViewController+Problem41.swift in Sources */,
 				13C1CC3327E0FFD5008AF400 /* ViewController+Problem26.swift in Sources */,
 				13C1CC7027E25C8D008AF400 /* ViewController+Problem34.swift in Sources */,
 				1389293A27DB4472003B5855 /* ViewController+Problem7.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
@@ -1,0 +1,109 @@
+//
+//  ViewController+Problem41.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 17/03/2022.
+//
+
+import Foundation
+/*
+ 987. Vertical Order Traversal of a Binary Tree
+ https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/
+ Given the root of a binary tree, calculate the vertical order traversal of the binary tree.
+ For each node at position (row, col), its left and right children will be at positions (row + 1, col - 1) and (row + 1, col + 1) respectively. The root of the tree is at (0, 0).
+ The vertical order traversal of a binary tree is a list of top-to-bottom orderings for each column index starting from the leftmost column and ending on the rightmost column. There may be multiple nodes in the same row and same column. In such a case, sort these nodes by their values.
+ Return the vertical order traversal of the binary tree.
+
+ Example 1:
+ Input: root = [3,9,20,null,null,15,7]
+ Output: [[9],[3,15],[20],[7]]
+ Explanation:
+ Column -1: Only node 9 is in this column.
+ Column 0: Nodes 3 and 15 are in this column in that order from top to bottom.
+ Column 1: Only node 20 is in this column.
+ Column 2: Only node 7 is in this column.
+
+ Example 2:
+ Input: root = [1,2,3,4,5,6,7]
+ Output: [[4],[2],[1,5,6],[3],[7]]
+ Explanation:
+ Column -2: Only node 4 is in this column.
+ Column -1: Only node 2 is in this column.
+ Column 0: Nodes 1, 5, and 6 are in this column.
+           1 is at the top, so it comes first.
+           5 and 6 are at the same position (2, 0), so we order them by their value, 5 before 6.
+ Column 1: Only node 3 is in this column.
+ Column 2: Only node 7 is in this column.
+
+ Example 3:
+ Input: root = [1,2,3,4,6,5,7]
+ Output: [[4],[2],[1,5,6],[3],[7]]
+ Explanation:
+ This case is the exact same as example 2, but with nodes 5 and 6 swapped.
+ Note that the solution remains the same since 5 and 6 are in the same location and should be ordered by their values.
+ */
+
+extension ViewController {
+    func solve41() {
+        print("Setting up Problem41 input!")
+        let root = TreeNode(1)
+        root.left = TreeNode(2)
+        root.right = TreeNode(3)
+        root.left?.left = TreeNode(4)
+        root.left?.right = TreeNode(5)
+        root.right?.left = TreeNode(6)
+        root.right?.right = TreeNode(7)
+
+        let output = Solution().verticalTraversal(root)
+        print("Output: \(output)")
+    }
+}
+
+fileprivate class Solution {
+    func verticalTraversal(_ root: TreeNode?) -> [[Int]] {
+        guard let root = root else { return [[]] }
+
+        var depthWithValuesMap: [Int: [Int]] = [:]
+        let queue = Queue<NodeInfo>()
+        queue.enQueue(NodeInfo(root, 0))
+
+        while queue.isEmpty == false {
+            let currentNodeInfo = queue.deQueue()!
+            let currentNode = currentNodeInfo.node
+            let currentDepth = currentNodeInfo.depth
+
+            if let currentDepthMap = depthWithValuesMap[currentDepth] {
+                depthWithValuesMap[currentDepth] = currentDepthMap + [currentNode.val]
+            } else {
+                depthWithValuesMap[currentDepth] = [currentNode.val]
+            }
+
+            if let leftNode = currentNode.left {
+                queue.enQueue(NodeInfo(leftNode, currentDepth-1))
+            }
+
+            if let rightNode = currentNode.right {
+                queue.enQueue(NodeInfo(rightNode, currentDepth+1))
+            }
+        }
+
+        var outputArray: [[Int]] = []
+        let sortedData = depthWithValuesMap.sorted(by: { $0.key < $1.key })
+
+        for (_, value) in sortedData {
+            outputArray.append(value)
+        }
+
+        return outputArray
+    }
+}
+
+class NodeInfo {
+    let node: TreeNode
+    let depth: Int
+
+    init(_ node: TreeNode, _ depth: Int) {
+        self.node = node
+        self.depth = depth
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
@@ -50,8 +50,8 @@ extension ViewController {
         root.left = TreeNode(2)
         root.right = TreeNode(3)
         root.left?.left = TreeNode(4)
-        root.left?.right = TreeNode(5)
-        root.right?.left = TreeNode(6)
+        root.left?.right = TreeNode(6)
+        root.right?.left = TreeNode(5)
         root.right?.right = TreeNode(7)
 
         let output = Solution().verticalTraversal(root)
@@ -63,35 +63,42 @@ fileprivate class Solution {
     func verticalTraversal(_ root: TreeNode?) -> [[Int]] {
         guard let root = root else { return [[]] }
 
-        var depthWithValuesMap: [Int: [Int]] = [:]
+        var depthWithValuesMap: [Int: [NodeInfo]] = [:]
         let queue = Queue<NodeInfo>()
-        queue.enQueue(NodeInfo(root, 0))
+        queue.enQueue(NodeInfo(root, 0, 0))
 
         while queue.isEmpty == false {
             let currentNodeInfo = queue.deQueue()!
             let currentNode = currentNodeInfo.node
-            let currentDepth = currentNodeInfo.depth
+            let currentRow = currentNodeInfo.row
+            let currentColumn = currentNodeInfo.column
 
-            if let currentDepthMap = depthWithValuesMap[currentDepth] {
-                depthWithValuesMap[currentDepth] = currentDepthMap + [currentNode.val]
+            if let currentDepthMap = depthWithValuesMap[currentColumn] {
+                depthWithValuesMap[currentColumn] = currentDepthMap + [currentNodeInfo]
             } else {
-                depthWithValuesMap[currentDepth] = [currentNode.val]
+                depthWithValuesMap[currentColumn] = [currentNodeInfo]
             }
 
             if let leftNode = currentNode.left {
-                queue.enQueue(NodeInfo(leftNode, currentDepth-1))
+                queue.enQueue(NodeInfo(leftNode, currentRow+1, currentColumn-1))
             }
 
             if let rightNode = currentNode.right {
-                queue.enQueue(NodeInfo(rightNode, currentDepth+1))
+                queue.enQueue(NodeInfo(rightNode, currentRow+1, currentColumn+1))
             }
         }
 
         var outputArray: [[Int]] = []
-        let sortedData = depthWithValuesMap.sorted(by: { $0.key < $1.key })
+        let sortedMap = depthWithValuesMap.sorted(by: { $0.key < $1.key })
 
-        for (_, value) in sortedData {
-            outputArray.append(value)
+        for (_, value) in sortedMap {
+            let sortedValues = value.sorted {
+                if $0.row == $1.row { return $0.node.val < $1.node.val }
+                return $0.column < $1.column
+            }
+
+            let intValues = sortedValues.map { $0.node.val }
+            outputArray.append(intValues)
         }
 
         return outputArray
@@ -100,10 +107,12 @@ fileprivate class Solution {
 
 class NodeInfo {
     let node: TreeNode
-    let depth: Int
+    let row: Int
+    let column: Int
 
-    init(_ node: TreeNode, _ depth: Int) {
+    init(_ node: TreeNode, _ row: Int, _ column: Int) {
         self.node = node
-        self.depth = depth
+        self.row = row
+        self.column = column
     }
 }

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -53,5 +53,6 @@ class ViewController: UIViewController {
         solve38()
         solve39()
         solve40()
+        solve41()
     }
 }

--- a/README.md
+++ b/README.md
@@ -224,3 +224,6 @@ Day45: 17-March-2022
 - [x] [LeetCode-1448: Count Good Nodes in Binary Tree](https://leetcode.com/problems/count-good-nodes-in-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem38.swift)
 - [x] [LeetCode-1026: Maximum Difference Between Node and Ancestor](https://leetcode.com/problems/maximum-difference-between-node-and-ancestor/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem39.swift)
 - [x] [LeetCode-1123: Lowest Common Ancestor of Deepest Leaves](https://leetcode.com/problems/lowest-common-ancestor-of-deepest-leaves/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem40.swift)
+
+Day46: 18-March-2022
+- [x] [LeetCode-987: Vertical Order Traversal of a Binary Tree](https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem41.swift)


### PR DESCRIPTION
987. Vertical Order Traversal of a Binary Tree
 https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/
 Given the root of a binary tree, calculate the vertical order traversal of the binary tree.
 For each node at position (row, col), its left and right children will be at positions (row + 1, col - 1) and (row + 1, col + 1) respectively. The root of the tree is at (0, 0).
 The vertical order traversal of a binary tree is a list of top-to-bottom orderings for each column index starting from the leftmost column and ending on the rightmost column. There may be multiple nodes in the same row and same column. In such a case, sort these nodes by their values.
 Return the vertical order traversal of the binary tree.

 Example 1:
 Input: root = [3,9,20,null,null,15,7]
 Output: [[9],[3,15],[20],[7]]
 Explanation:
 Column -1: Only node 9 is in this column.
 Column 0: Nodes 3 and 15 are in this column in that order from top to bottom.
 Column 1: Only node 20 is in this column.
 Column 2: Only node 7 is in this column.

 Example 2:
 Input: root = [1,2,3,4,5,6,7]
 Output: [[4],[2],[1,5,6],[3],[7]]
 Explanation:
 Column -2: Only node 4 is in this column.
 Column -1: Only node 2 is in this column.
 Column 0: Nodes 1, 5, and 6 are in this column.
           1 is at the top, so it comes first.
           5 and 6 are at the same position (2, 0), so we order them by their value, 5 before 6.
 Column 1: Only node 3 is in this column.
 Column 2: Only node 7 is in this column.

 Example 3:
 Input: root = [1,2,3,4,6,5,7]
 Output: [[4],[2],[1,5,6],[3],[7]]
 Explanation:
 This case is the exact same as example 2, but with nodes 5 and 6 swapped.
 Note that the solution remains the same since 5 and 6 are in the same location and should be ordered by their values.