### PR TITLE
Day46: 'Maximum Width of Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		13C1CC8A27E39971008AF400 /* ViewController+Problem39.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */; };
 		13C1CC8C27E3A46B008AF400 /* ViewController+Problem40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */; };
 		13C1CC8E27E3C759008AF400 /* ViewController+Problem41.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */; };
+		13C1CC9027E4AAA1008AF400 /* ViewController+Problem42.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CC8F27E4AAA1008AF400 /* ViewController+Problem42.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -110,6 +111,7 @@
 		13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem39.swift"; sourceTree = "<group>"; };
 		13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem40.swift"; sourceTree = "<group>"; };
 		13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem41.swift"; sourceTree = "<group>"; };
+		13C1CC8F27E4AAA1008AF400 /* ViewController+Problem42.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem42.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +190,7 @@
 				13C1CC8927E39971008AF400 /* ViewController+Problem39.swift */,
 				13C1CC8B27E3A46B008AF400 /* ViewController+Problem40.swift */,
 				13C1CC8D27E3C759008AF400 /* ViewController+Problem41.swift */,
+				13C1CC8F27E4AAA1008AF400 /* ViewController+Problem42.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -297,6 +300,7 @@
 				13B00B1827DBAC400061E451 /* ViewController+Problem8.swift in Sources */,
 				138928EC27D936E3003B5855 /* ViewController+Problem4.swift in Sources */,
 				13A5F2DE27D7481D00515002 /* ViewController+Problem1.swift in Sources */,
+				13C1CC9027E4AAA1008AF400 /* ViewController+Problem42.swift in Sources */,
 				13C1CC0027DF3ED7008AF400 /* ViewController+Problem20.swift in Sources */,
 				13C1CC1827E0A614008AF400 /* ViewController+Problem24.swift in Sources */,
 				13A3675427D7DBE70098E2EA /* ViewController+Problem2.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/Queue.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/Queue.swift
@@ -12,6 +12,10 @@ class Queue<T> {
 
     var isEmpty: Bool { return array.isEmpty }
 
+    var count: Int { return array.count }
+
+    var front: T? { array.first }
+
     func enQueue(_ value: T) {
         array.append(value)
     }

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem41.swift
@@ -105,7 +105,7 @@ fileprivate class Solution {
     }
 }
 
-class NodeInfo {
+private class NodeInfo {
     let node: TreeNode
     let row: Int
     let column: Int

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem42.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem42.swift
@@ -1,0 +1,89 @@
+//
+//  ViewController+Problem42.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 18/03/2022.
+//
+
+import Foundation
+/*
+ 662. Maximum Width of Binary Tree
+ https://leetcode.com/problems/maximum-width-of-binary-tree/
+ Given the root of a binary tree, return the maximum width of the given tree.
+ The maximum width of a tree is the maximum width among all levels.
+ The width of one level is defined as the length between the end-nodes (the leftmost and rightmost non-null nodes), where the null nodes between the end-nodes that would be present in a complete binary tree extending down to that level are also counted into the length calculation.
+ It is guaranteed that the answer will in the range of a 32-bit signed integer.
+
+ Example 1:
+ Input: root = [1,3,2,5,3,null,9]
+ Output: 4
+ Explanation: The maximum width exists in the third level with length 4 (5,3,null,9).
+
+ Example 2:
+ Input: root = [1,3,2,5,null,null,9,6,null,7]
+ Output: 7
+ Explanation: The maximum width exists in the fourth level with length 7 (6,null,null,null,null,null,7).
+ */
+
+extension ViewController {
+    func solve42() {
+        print("Setting up Problem42 input!")
+        let root = TreeNode(1)
+        root.left = TreeNode(3)
+        root.right = TreeNode(2)
+        root.left?.left = TreeNode(5)
+
+        let output = Solution().widthOfBinaryTree(root)
+        print("Output: \(output)")
+    }
+}
+
+fileprivate class Solution {
+    func widthOfBinaryTree(_ root: TreeNode?) -> Int {
+        guard let root = root else { return 0 }
+
+        var maxWidth = Int.min
+        let queue = Queue<NodeInfo>()
+        queue.enQueue(NodeInfo(root, 0))
+
+        while queue.isEmpty == false {
+            var firstNodeInfoIndex: Int64 = 0
+            var lastNodeInfoIndex: Int64 = 0
+            let currentLevelStartingIndex = queue.front!.index
+            let currentLevelNodeCount = queue.count
+
+            for i in 0..<currentLevelNodeCount {
+                let currentNodeInfo = queue.deQueue()!
+                let currentNodeIndex = currentNodeInfo.index - currentLevelStartingIndex
+
+                if i == 0 { firstNodeInfoIndex = currentNodeIndex }
+                if i == currentLevelNodeCount-1 { lastNodeInfoIndex = currentNodeIndex }
+
+                let newIndex = (currentNodeIndex*2)
+
+                if let leftNode = currentNodeInfo.node.left {
+                    queue.enQueue(NodeInfo(leftNode, newIndex))
+                }
+
+                if let rightNode = currentNodeInfo.node.right {
+                    queue.enQueue(NodeInfo(rightNode, newIndex+1))
+                }
+            }
+
+            let currentLevelWidth = Int(lastNodeInfoIndex - firstNodeInfoIndex + 1)
+            maxWidth = max(maxWidth, currentLevelWidth)
+        }
+
+        return maxWidth
+    }
+}
+
+private struct NodeInfo {
+    let node: TreeNode
+    let index: Int64
+
+    init(_ node: TreeNode, _ index: Int64) {
+        self.node = node
+        self.index = index
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -54,5 +54,6 @@ class ViewController: UIViewController {
         solve39()
         solve40()
         solve41()
+        solve42()
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Data Structure &amp; Algorithms (Swift language)
 ![![License]](https://img.shields.io/badge/license-MIT-green.svg?style=flat)
 [![Twitter: @iammanishrathi](https://img.shields.io/badge/contact-@iammanishrathi-blue.svg?style=flat)](https://twitter.com/iammanishrathi)
 ------
-**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/045-days-green.svg?style=flat)
+**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/046-days-green.svg?style=flat)
 
 Data Structure Goals:
 - [x] Array
@@ -227,3 +227,4 @@ Day45: 17-March-2022
 
 Day46: 18-March-2022
 - [x] [LeetCode-987: Vertical Order Traversal of a Binary Tree](https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem41.swift)
+- [x] [LeetCode-662: Maximum Width of Binary Tree](https://leetcode.com/problems/maximum-width-of-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem42.swift)


### PR DESCRIPTION
 662. Maximum Width of Binary Tree
 https://leetcode.com/problems/maximum-width-of-binary-tree/
 Given the root of a binary tree, return the maximum width of the given tree.
 The maximum width of a tree is the maximum width among all levels.
 The width of one level is defined as the length between the end-nodes (the leftmost and rightmost non-null nodes), where the null nodes between the end-nodes that would be present in a complete binary tree extending down to that level are also counted into the length calculation.
 It is guaranteed that the answer will in the range of a 32-bit signed integer.

 Example 1:
 Input: root = [1,3,2,5,3,null,9]
 Output: 4
 Explanation: The maximum width exists in the third level with length 4 (5,3,null,9).

 Example 2:
 Input: root = [1,3,2,5,null,null,9,6,null,7]
 Output: 7
 Explanation: The maximum width exists in the fourth level with length 7 (6,null,null,null,null,null,7).