### PR TITLE
Day47: 'Lowest Common Ancestor of a Binary Tree' solution

### DIFF
--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		13C1CCC827E53EC9008AF400 /* ViewController+Problem52.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CCC727E53EC9008AF400 /* ViewController+Problem52.swift */; };
 		13C1CCCA27E54574008AF400 /* ViewController+Problem53.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CCC927E54574008AF400 /* ViewController+Problem53.swift */; };
 		13C1CCCC27E55052008AF400 /* ViewController+Problem54.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CCCB27E55052008AF400 /* ViewController+Problem54.swift */; };
+		13C1CCCE27E5BE8E008AF400 /* ViewController+Problem55.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C1CCCD27E5BE8E008AF400 /* ViewController+Problem55.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -138,6 +139,7 @@
 		13C1CCC727E53EC9008AF400 /* ViewController+Problem52.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem52.swift"; sourceTree = "<group>"; };
 		13C1CCC927E54574008AF400 /* ViewController+Problem53.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem53.swift"; sourceTree = "<group>"; };
 		13C1CCCB27E55052008AF400 /* ViewController+Problem54.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem54.swift"; sourceTree = "<group>"; };
+		13C1CCCD27E5BE8E008AF400 /* ViewController+Problem55.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Problem55.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,6 +232,7 @@
 				13C1CCC727E53EC9008AF400 /* ViewController+Problem52.swift */,
 				13C1CCC927E54574008AF400 /* ViewController+Problem53.swift */,
 				13C1CCCB27E55052008AF400 /* ViewController+Problem54.swift */,
+				13C1CCCD27E5BE8E008AF400 /* ViewController+Problem55.swift */,
 				1357CC7627D741F200A29264 /* Main.storyboard */,
 				1357CC7927D741F500A29264 /* Assets.xcassets */,
 				1357CC7B27D741F500A29264 /* LaunchScreen.storyboard */,
@@ -317,6 +320,7 @@
 				13A3675627D86E120098E2EA /* ViewController+Problem3.swift in Sources */,
 				13C1CC1227DFBBC7008AF400 /* ViewController+Problem21.swift in Sources */,
 				13C1CC3927E1C503008AF400 /* ViewController+Problem29.swift in Sources */,
+				13C1CCCE27E5BE8E008AF400 /* ViewController+Problem55.swift in Sources */,
 				13C1CC6E27E24AD5008AF400 /* ViewController+Problem33.swift in Sources */,
 				13C1CC3F27E2012A008AF400 /* ViewController+Problem32.swift in Sources */,
 				13C1CC1627E08DC1008AF400 /* ViewController+Problem23.swift in Sources */,

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem55.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController+Problem55.swift
@@ -1,0 +1,69 @@
+//
+//  ViewController+Problem55.swift
+//  BinaryTree
+//
+//  Created by Manish Rathi on 19/03/2022.
+//
+
+import Foundation
+/*
+ 236. Lowest Common Ancestor of a Binary Tree
+ https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree/
+ Given a binary tree, find the lowest common ancestor (LCA) of two given nodes in the tree.
+ According to the definition of LCA on Wikipedia: “The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has both p and q as descendants (where we allow a node to be a descendant of itself).”
+
+ Example 1:
+ Input: root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 1
+ Output: 3
+ Explanation: The LCA of nodes 5 and 1 is 3.
+
+ Example 2:
+ Input: root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 4
+ Output: 5
+ Explanation: The LCA of nodes 5 and 4 is 5, since a node can be a descendant of itself according to the LCA definition.
+
+ Example 3:
+ Input: root = [1,2], p = 1, q = 2
+ Output: 1
+ */
+
+extension ViewController {
+    func solve55() {
+        print("Setting up Problem55 input!")
+        let root = TreeNode(3)
+        root.left = TreeNode(5)
+        root.right = TreeNode(1)
+        root.left?.left = TreeNode(6)
+        root.left?.right = TreeNode(2)
+        root.right?.left = TreeNode(0)
+        root.right?.right = TreeNode(8)
+        root.left?.right?.left = TreeNode(7)
+        root.left?.right?.right = TreeNode(4)
+
+        let output = Solution().findLowestLCA(root, 5, 1)
+        print("Output: \(output!.val)")
+    }
+}
+
+fileprivate class Solution {
+    func lowestCommonAncestor(_ root: TreeNode?, _ p: TreeNode?, _ q: TreeNode?) -> TreeNode? {
+        guard let root = root, let p = p, let q = q else { return nil }
+
+        return findLowestLCA(root, p.val, q.val)
+    }
+
+    func findLowestLCA(_ root: TreeNode?, _ p: Int, _ q: Int) -> TreeNode? {
+        guard let currentNode = root else { return nil }
+
+        if currentNode.val == p || currentNode.val == q { return currentNode }
+
+        let leftLowestLCA = findLowestLCA(currentNode.left, p, q)
+        let rightLowestLCA = findLowestLCA(currentNode.right, p, q)
+
+        if leftLowestLCA != nil && rightLowestLCA != nil { return currentNode }
+        if leftLowestLCA != nil { return leftLowestLCA }
+        if rightLowestLCA != nil { return rightLowestLCA }
+
+        return nil
+    }
+}

--- a/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
+++ b/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController.swift
@@ -67,5 +67,6 @@ class ViewController: UIViewController {
         solve52()
         solve53()
         solve54()
+        solve55()
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Data Structure &amp; Algorithms (Swift language)
 ![![License]](https://img.shields.io/badge/license-MIT-green.svg?style=flat)
 [![Twitter: @iammanishrathi](https://img.shields.io/badge/contact-@iammanishrathi-blue.svg?style=flat)](https://twitter.com/iammanishrathi)
 ------
-**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/046-days-green.svg?style=flat)
+**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/047-days-green.svg?style=flat)
 
 Data Structure Goals:
 - [x] Array
@@ -240,3 +240,6 @@ Day46: 18-March-2022
 - [x] [LeetCode-129: Sum Root to Leaf Numbers](https://leetcode.com/problems/sum-root-to-leaf-numbers/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem52.swift)
 - [x] [LeetCode-113: Path Sum II](https://leetcode.com/problems/path-sum-ii/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem53.swift)
 - [x] [LeetCode-124: Binary Tree Maximum Path Sum](https://leetcode.com/problems/binary-tree-maximum-path-sum/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem54.swift)
+
+Day47: 19-March-2022
+- [x] [LeetCode-236: Lowest Common Ancestor of a Binary Tree](https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/BinaryTree/BinaryTree/BinaryTree/ViewController%2BProblem55.swift)


### PR DESCRIPTION
 236. Lowest Common Ancestor of a Binary Tree
 https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree/
 Given a binary tree, find the lowest common ancestor (LCA) of two given nodes in the tree.
 According to the definition of LCA on Wikipedia: “The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has both p and q as descendants (where we allow a node to be a descendant of itself).”

 Example 1:
 Input: root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 1
 Output: 3
 Explanation: The LCA of nodes 5 and 1 is 3.

 Example 2:
 Input: root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 4
 Output: 5
 Explanation: The LCA of nodes 5 and 4 is 5, since a node can be a descendant of itself according to the LCA definition.

 Example 3:
 Input: root = [1,2], p = 1, q = 2
 Output: 1