### PR TITLE
Day54: LeetCode-929. Unique Email Addresses - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		136125BE27EFC0DC0081672D /* ViewController+Challenge19.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125BD27EFC0DC0081672D /* ViewController+Challenge19.swift */; };
 		136125C027EFCE170081672D /* ViewController+Challenge20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125BF27EFCE170081672D /* ViewController+Challenge20.swift */; };
 		136125C227F067A20081672D /* ViewController+Challenge21.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C127F067A20081672D /* ViewController+Challenge21.swift */; };
+		136125C427F06D7F0081672D /* ViewController+Challenge22.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C327F06D7F0081672D /* ViewController+Challenge22.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +67,7 @@
 		136125BD27EFC0DC0081672D /* ViewController+Challenge19.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge19.swift"; sourceTree = "<group>"; };
 		136125BF27EFCE170081672D /* ViewController+Challenge20.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge20.swift"; sourceTree = "<group>"; };
 		136125C127F067A20081672D /* ViewController+Challenge21.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge21.swift"; sourceTree = "<group>"; };
+		136125C327F06D7F0081672D /* ViewController+Challenge22.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge22.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 				136125BD27EFC0DC0081672D /* ViewController+Challenge19.swift */,
 				136125BF27EFCE170081672D /* ViewController+Challenge20.swift */,
 				136125C127F067A20081672D /* ViewController+Challenge21.swift */,
+				136125C327F06D7F0081672D /* ViewController+Challenge22.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -216,6 +219,7 @@
 				1361258627EE5DC80081672D /* AppDelegate.swift in Sources */,
 				136125B227EF7BC00081672D /* ViewController+Challenge13.swift in Sources */,
 				136125C227F067A20081672D /* ViewController+Challenge21.swift in Sources */,
+				136125C427F06D7F0081672D /* ViewController+Challenge22.swift in Sources */,
 				136125A227EF53140081672D /* ViewController+Challenge5.swift in Sources */,
 				136125AE27EF730E0081672D /* ViewController+Challenge11.swift in Sources */,
 				136125A027EE78CF0081672D /* ViewController+Challenge4.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge22.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge22.swift
@@ -1,0 +1,65 @@
+//
+//  ViewController+Challenge22.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 27/03/2022.
+//
+
+import Foundation
+/*
+ 929. Unique Email Addresses
+ https://leetcode.com/problems/unique-email-addresses/
+ Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.
+ For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
+ If you add periods '.' between some characters in the local name part of an email address, mail sent there will be forwarded to the same address without dots in the local name. Note that this rule does not apply to domain names.
+ For example, "alice.z@leetcode.com" and "alicez@leetcode.com" forward to the same email address.
+ If you add a plus '+' in the local name, everything after the first plus sign will be ignored. This allows certain emails to be filtered. Note that this rule does not apply to domain names.
+ For example, "m.y+name@email.com" will be forwarded to "my@email.com".
+ It is possible to use both of these rules at the same time.
+ Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.
+
+ Example 1:
+ Input: emails = ["test.email+alex@leetcode.com","test.e.mail+bob.cathy@leetcode.com","testemail+david@lee.tcode.com"]
+ Output: 2
+ Explanation: "testemail@leetcode.com" and "testemail@lee.tcode.com" actually receive mails.
+
+ Example 2:
+ Input: emails = ["a@leetcode.com","b@leetcode.com","c@leetcode.com"]
+ Output: 3
+ */
+
+extension ViewController {
+    func solve22() {
+        print("Setting up Challenge22 input!")
+
+        let input = ["test.email+alex@leetcode.com","test.e.mail+bob.cathy@leetcode.com","testemail+david@lee.tcode.com"]
+        print("Input: \(input)")
+        let output = Solution().numUniqueEmails(input)
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func numUniqueEmails(_ emails: [String]) -> Int {
+        var uniqueEmailsHashMap: [String : Bool] = [:]
+        var uniqueEmailsCounter = 0
+
+        for email in emails {
+            let emailComponents = email.components(separatedBy: "@")
+            var localName = emailComponents[0]
+            let domainName = emailComponents[1]
+
+            localName = localName.components(separatedBy: "+")[0]
+            localName = localName.replacingOccurrences(of: ".", with: "")
+
+            let forwardedEmail = localName + "@" + domainName
+
+            if uniqueEmailsHashMap[forwardedEmail] == nil {
+                uniqueEmailsHashMap[forwardedEmail] = true
+                uniqueEmailsCounter += 1
+            }
+        }
+
+        return uniqueEmailsCounter
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -33,6 +33,7 @@ class ViewController: UIViewController {
         solve19()
         solve20()
         solve21()
+        solve22()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -325,3 +325,4 @@ Day54:
 
 Day55:
 - [x] [LeetCode-1160. Find Words That Can Be Formed by Characters](https://leetcode.com/problems/find-words-that-can-be-formed-by-characters/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge21.swift)
+- [x] [LeetCode-929. Unique Email Addresses](https://leetcode.com/problems/unique-email-addresses/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge22.swift)


### PR DESCRIPTION
 929. Unique Email Addresses
 https://leetcode.com/problems/unique-email-addresses/
 Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.
 For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
 If you add periods '.' between some characters in the local name part of an email address, mail sent there will be forwarded to the same address without dots in the local name. Note that this rule does not apply to domain names.
 For example, "alice.z@leetcode.com" and "alicez@leetcode.com" forward to the same email address.
 If you add a plus '+' in the local name, everything after the first plus sign will be ignored. This allows certain emails to be filtered. Note that this rule does not apply to domain names.
 For example, "m.y+name@email.com" will be forwarded to "my@email.com".
 It is possible to use both of these rules at the same time.
 Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.

 Example 1:
 Input: emails = ["test.email+alex@leetcode.com","test.e.mail+bob.cathy@leetcode.com","testemail+david@lee.tcode.com"]
 Output: 2
 Explanation: "testemail@leetcode.com" and "testemail@lee.tcode.com" actually receive mails.

 Example 2:
 Input: emails = ["a@leetcode.com","b@leetcode.com","c@leetcode.com"]
 Output: 3