### PR TITLE
Day56: LeetCode-2068. Check Whether Two Strings are Almost Equivalent - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		136125C227F067A20081672D /* ViewController+Challenge21.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C127F067A20081672D /* ViewController+Challenge21.swift */; };
 		136125C427F06D7F0081672D /* ViewController+Challenge22.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C327F06D7F0081672D /* ViewController+Challenge22.swift */; };
 		136125C627F0759C0081672D /* ViewController+Challenge23.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C527F0759C0081672D /* ViewController+Challenge23.swift */; };
+		136125C827F080660081672D /* ViewController+Challenge24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125C727F080660081672D /* ViewController+Challenge24.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		136125C127F067A20081672D /* ViewController+Challenge21.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge21.swift"; sourceTree = "<group>"; };
 		136125C327F06D7F0081672D /* ViewController+Challenge22.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge22.swift"; sourceTree = "<group>"; };
 		136125C527F0759C0081672D /* ViewController+Challenge23.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge23.swift"; sourceTree = "<group>"; };
+		136125C727F080660081672D /* ViewController+Challenge24.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge24.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 				136125C127F067A20081672D /* ViewController+Challenge21.swift */,
 				136125C327F06D7F0081672D /* ViewController+Challenge22.swift */,
 				136125C527F0759C0081672D /* ViewController+Challenge23.swift */,
+				136125C727F080660081672D /* ViewController+Challenge24.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -227,6 +230,7 @@
 				136125A227EF53140081672D /* ViewController+Challenge5.swift in Sources */,
 				136125AE27EF730E0081672D /* ViewController+Challenge11.swift in Sources */,
 				136125A027EE78CF0081672D /* ViewController+Challenge4.swift in Sources */,
+				136125C827F080660081672D /* ViewController+Challenge24.swift in Sources */,
 				136125A827EF63480081672D /* ViewController+Challenge8.swift in Sources */,
 				136125AC27EF6E8B0081672D /* ViewController+Challenge10.swift in Sources */,
 				1361258827EE5DC80081672D /* SceneDelegate.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge24.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge24.swift
@@ -1,0 +1,98 @@
+//
+//  ViewController+Challenge24.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 27/03/2022.
+//
+
+import Foundation
+/*
+ 2068. Check Whether Two Strings are Almost Equivalent
+ https://leetcode.com/problems/check-whether-two-strings-are-almost-equivalent/
+ Two strings word1 and word2 are considered almost equivalent if the differences between the frequencies of each letter from 'a' to 'z' between word1 and word2 is at most 3.
+
+ Given two strings word1 and word2, each of length n, return true if word1 and word2 are almost equivalent, or false otherwise.
+ The frequency of a letter x is the number of times it occurs in the string.
+
+ Example 1:
+ Input: word1 = "aaaa", word2 = "bccb"
+ Output: false
+ Explanation: There are 4 'a's in "aaaa" but 0 'a's in "bccb".
+ The difference is 4, which is more than the allowed 3.
+
+ Example 2:
+ Input: word1 = "abcdeef", word2 = "abaaacc"
+ Output: true
+ Explanation: The differences between the frequencies of each letter in word1 and word2 are at most 3:
+ - 'a' appears 1 time in word1 and 4 times in word2. The difference is 3.
+ - 'b' appears 1 time in word1 and 1 time in word2. The difference is 0.
+ - 'c' appears 1 time in word1 and 2 times in word2. The difference is 1.
+ - 'd' appears 1 time in word1 and 0 times in word2. The difference is 1.
+ - 'e' appears 2 times in word1 and 0 times in word2. The difference is 2.
+ - 'f' appears 1 time in word1 and 0 times in word2. The difference is 1.
+
+ Example 3:
+ Input: word1 = "cccddabba", word2 = "babababab"
+ Output: true
+ Explanation: The differences between the frequencies of each letter in word1 and word2 are at most 3:
+ - 'a' appears 2 times in word1 and 4 times in word2. The difference is 2.
+ - 'b' appears 2 times in word1 and 5 times in word2. The difference is 3.
+ - 'c' appears 3 times in word1 and 0 times in word2. The difference is 3.
+ - 'd' appears 2 times in word1 and 0 times in word2. The difference is 2.
+ */
+
+extension ViewController {
+    func solve24() {
+        print("Setting up Challenge24 input!")
+
+        let input = "abcdeef"
+        print("Input: \(input)")
+        let output = Solution().checkAlmostEquivalent(input, "abaaacc")
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func checkAlmostEquivalent(_ word1: String, _ word2: String) -> Bool {
+        let word1HashMap = addIntoHashMap(word1)
+        let word2HashMap = addIntoHashMap(word2)
+
+        var isEquivalent = true
+        isEquivalent = isAlmostEquivalent(word1HashMap, word2HashMap)
+
+        if isEquivalent {
+            isEquivalent = isAlmostEquivalent(word2HashMap, word1HashMap)
+        }
+
+        return isEquivalent
+    }
+
+    private func addIntoHashMap(_ word: String) -> [Character : Int] {
+        var hashMap: [Character : Int] = [:]
+
+        for char in word {
+            if let hashMapValue = hashMap[char] {
+                hashMap[char] = hashMapValue + 1
+            } else {
+                hashMap[char] = 1
+            }
+        }
+
+        return hashMap
+    }
+
+    private func isAlmostEquivalent(_ hash1: [Character : Int], _ hash2: [Character : Int]) -> Bool {
+        var isAlmostEquivalent = true
+
+        for (key, value) in hash1 {
+            let hash2Value = hash2[key] ?? 0
+
+            if abs(hash2Value - value) > 3 {
+                isAlmostEquivalent = false
+                break
+            }
+        }
+
+        return isAlmostEquivalent
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -35,6 +35,7 @@ class ViewController: UIViewController {
         solve21()
         solve22()
         solve23()
+        solve24()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -329,3 +329,4 @@ Day55:
 
 Day56:
 - [x] [LeetCode-1399. Count Largest Group](https://leetcode.com/problems/count-largest-group/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge23.swift)
+- [x] [LeetCode-2068. Check Whether Two Strings are Almost Equivalent](https://leetcode.com/problems/check-whether-two-strings-are-almost-equivalent/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge24.swift)


### PR DESCRIPTION
 2068. Check Whether Two Strings are Almost Equivalent
 https://leetcode.com/problems/check-whether-two-strings-are-almost-equivalent/
 Two strings word1 and word2 are considered almost equivalent if the differences between the frequencies of each letter from 'a' to 'z' between word1 and word2 is at most 3.

 Given two strings word1 and word2, each of length n, return true if word1 and word2 are almost equivalent, or false otherwise.
 The frequency of a letter x is the number of times it occurs in the string.

 Example 1:
 Input: word1 = "aaaa", word2 = "bccb"
 Output: false
 Explanation: There are 4 'a's in "aaaa" but 0 'a's in "bccb".
 The difference is 4, which is more than the allowed 3.

 Example 2:
 Input: word1 = "abcdeef", word2 = "abaaacc"
 Output: true
 Explanation: The differences between the frequencies of each letter in word1 and word2 are at most 3:
 - 'a' appears 1 time in word1 and 4 times in word2. The difference is 3.
 - 'b' appears 1 time in word1 and 1 time in word2. The difference is 0.
 - 'c' appears 1 time in word1 and 2 times in word2. The difference is 1.
 - 'd' appears 1 time in word1 and 0 times in word2. The difference is 1.
 - 'e' appears 2 times in word1 and 0 times in word2. The difference is 2.
 - 'f' appears 1 time in word1 and 0 times in word2. The difference is 1.

 Example 3:
 Input: word1 = "cccddabba", word2 = "babababab"
 Output: true
 Explanation: The differences between the frequencies of each letter in word1 and word2 are at most 3:
 - 'a' appears 2 times in word1 and 4 times in word2. The difference is 2.
 - 'b' appears 2 times in word1 and 5 times in word2. The difference is 3.
 - 'c' appears 3 times in word1 and 0 times in word2. The difference is 3.
 - 'd' appears 2 times in word1 and 0 times in word2. The difference is 2.