### PR TITLE
Day60: LeetCode-1897. Redistribute Characters to Make All Strings Equal - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		136125D627F0FDE40081672D /* ViewController+Challenge31.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125D527F0FDE40081672D /* ViewController+Challenge31.swift */; };
 		136125D827F0FF4E0081672D /* ViewController+Challenge32.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125D727F0FF4E0081672D /* ViewController+Challenge32.swift */; };
 		136125DA27F10E290081672D /* ViewController+Challenge33.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125D927F10E290081672D /* ViewController+Challenge33.swift */; };
+		136125DC27F10F590081672D /* ViewController+Challenge34.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136125DB27F10F590081672D /* ViewController+Challenge34.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +91,7 @@
 		136125D527F0FDE40081672D /* ViewController+Challenge31.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge31.swift"; sourceTree = "<group>"; };
 		136125D727F0FF4E0081672D /* ViewController+Challenge32.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge32.swift"; sourceTree = "<group>"; };
 		136125D927F10E290081672D /* ViewController+Challenge33.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge33.swift"; sourceTree = "<group>"; };
+		136125DB27F10F590081672D /* ViewController+Challenge34.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge34.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +160,7 @@
 				136125D527F0FDE40081672D /* ViewController+Challenge31.swift */,
 				136125D727F0FF4E0081672D /* ViewController+Challenge32.swift */,
 				136125D927F10E290081672D /* ViewController+Challenge33.swift */,
+				136125DB27F10F590081672D /* ViewController+Challenge34.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -239,6 +242,7 @@
 			files = (
 				136125D827F0FF4E0081672D /* ViewController+Challenge32.swift in Sources */,
 				136125BA27EFB67A0081672D /* ViewController+Challenge17.swift in Sources */,
+				136125DC27F10F590081672D /* ViewController+Challenge34.swift in Sources */,
 				1361259A27EE5E040081672D /* ViewController+Challenge1.swift in Sources */,
 				1361258A27EE5DC80081672D /* ViewController.swift in Sources */,
 				136125B627EFA92A0081672D /* ViewController+Challenge15.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge34.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge34.swift
@@ -1,0 +1,65 @@
+//
+//  ViewController+Challenge34.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 27/03/2022.
+//
+
+import Foundation
+/*
+ 1897. Redistribute Characters to Make All Strings Equal
+ https://leetcode.com/problems/redistribute-characters-to-make-all-strings-equal/
+ You are given an array of strings words (0-indexed).
+ In one operation, pick two distinct indices i and j, where words[i] is a non-empty string, and move any character from words[i] to any position in words[j].
+ Return true if you can make every string in words equal using any number of operations, and false otherwise.
+
+ Example 1:
+ Input: words = ["abc","aabc","bc"]
+ Output: true
+ Explanation: Move the first 'a' in words[1] to the front of words[2],
+ to make words[1] = "abc" and words[2] = "abc".
+ All the strings are now equal to "abc", so return true.
+
+ Example 2:
+ Input: words = ["ab","a"]
+ Output: false
+ Explanation: It is impossible to make all the strings equal using the operation.
+ */
+
+extension ViewController {
+    func solve34() {
+        print("Setting up Challenge34 input!")
+
+        let input = ["abc","aabc","bc"]
+        print("Input: \(input)")
+        let output = Solution().makeEqual(input)
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func makeEqual(_ words: [String]) -> Bool {
+        var hashMap: [Character : Int] = [:]
+
+        for word in words {
+            for char in word {
+                let hashMapValue = hashMap[char] ?? 0
+                hashMap[char] = hashMapValue + 1
+            }
+        }
+
+        let wordsCount = words.count
+
+        if wordsCount == 1 { return true }
+
+        var canMakeEqual = true
+        for (_, value) in hashMap {
+            if value % wordsCount != 0 {
+                canMakeEqual = false
+                break
+            }
+        }
+
+        return canMakeEqual
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
         solve31()
         solve32()
         solve33()
+        solve34()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -350,3 +350,4 @@ Day60:
 
 Day61:
 - [x] [LeetCode-389. Find the Difference](https://leetcode.com/problems/find-the-difference/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge33.swift)
+- [x] [LeetCode-1897. Redistribute Characters to Make All Strings Equal](https://leetcode.com/problems/redistribute-characters-to-make-all-strings-equal/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge34.swift)


### PR DESCRIPTION
 1897. Redistribute Characters to Make All Strings Equal
 https://leetcode.com/problems/redistribute-characters-to-make-all-strings-equal/
 You are given an array of strings words (0-indexed).
 In one operation, pick two distinct indices i and j, where words[i] is a non-empty string, and move any character from words[i] to any position in words[j].
 Return true if you can make every string in words equal using any number of operations, and false otherwise.

 Example 1:
 Input: words = ["abc","aabc","bc"]
 Output: true
 Explanation: Move the first 'a' in words[1] to the front of words[2],
 to make words[1] = "abc" and words[2] = "abc".
 All the strings are now equal to "abc", so return true.

 Example 2:
 Input: words = ["ab","a"]
 Output: false
 Explanation: It is impossible to make all the strings equal using the operation.