### PR TITLE
Day72: LeetCode-1790. Check if One String Swap Can Make Strings Equal - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		13DCCC6C27F351CA006F89CB /* ViewController+Challenge52.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC6B27F351CA006F89CB /* ViewController+Challenge52.swift */; };
 		13DCCC6E27F35451006F89CB /* ViewController+Challenge53.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC6D27F35451006F89CB /* ViewController+Challenge53.swift */; };
 		13DCCC7027F355CA006F89CB /* ViewController+Challenge54.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC6F27F355CA006F89CB /* ViewController+Challenge54.swift */; };
+		13DCCC7227F3576C006F89CB /* ViewController+Challenge55.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC7127F3576C006F89CB /* ViewController+Challenge55.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -132,6 +133,7 @@
 		13DCCC6B27F351CA006F89CB /* ViewController+Challenge52.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge52.swift"; sourceTree = "<group>"; };
 		13DCCC6D27F35451006F89CB /* ViewController+Challenge53.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge53.swift"; sourceTree = "<group>"; };
 		13DCCC6F27F355CA006F89CB /* ViewController+Challenge54.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge54.swift"; sourceTree = "<group>"; };
+		13DCCC7127F3576C006F89CB /* ViewController+Challenge55.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge55.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +223,7 @@
 				13DCCC6B27F351CA006F89CB /* ViewController+Challenge52.swift */,
 				13DCCC6D27F35451006F89CB /* ViewController+Challenge53.swift */,
 				13DCCC6F27F355CA006F89CB /* ViewController+Challenge54.swift */,
+				13DCCC7127F3576C006F89CB /* ViewController+Challenge55.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -316,6 +319,7 @@
 				1361259E27EE689F0081672D /* ViewController+Challenge3.swift in Sources */,
 				136125D227F0EF3A0081672D /* ViewController+Challenge29.swift in Sources */,
 				136125AA27EF67EA0081672D /* ViewController+Challenge9.swift in Sources */,
+				13DCCC7227F3576C006F89CB /* ViewController+Challenge55.swift in Sources */,
 				136125D427F0F80D0081672D /* ViewController+Challenge30.swift in Sources */,
 				13DCCC7027F355CA006F89CB /* ViewController+Challenge54.swift in Sources */,
 				136125C027EFCE170081672D /* ViewController+Challenge20.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge55.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge55.swift
@@ -1,0 +1,103 @@
+//
+//  ViewController+Challenge55.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 29/03/2022.
+//
+
+import Foundation
+/*
+ 1790. Check if One String Swap Can Make Strings Equal
+ https://leetcode.com/problems/check-if-one-string-swap-can-make-strings-equal/
+ You are given two strings s1 and s2 of equal length. A string swap is an operation where you choose two indices in a string (not necessarily different) and swap the characters at these indices.
+
+ Return true if it is possible to make both strings equal by performing at most one string swap on exactly one of the strings. Otherwise, return false.
+
+ Example 1:
+ Input: s1 = "bank", s2 = "kanb"
+ Output: true
+ Explanation: For example, swap the first character with the last character of s2 to make "bank".
+
+ Example 2:
+ Input: s1 = "attack", s2 = "defend"
+ Output: false
+ Explanation: It is impossible to make them equal with one string swap.
+
+ Example 3:
+ Input: s1 = "kelb", s2 = "kelb"
+ Output: true
+ Explanation: The two strings are already equal, so no string swap operation is required.
+ */
+
+extension ViewController {
+    func solve55() {
+        print("Setting up Challenge55 input!")
+
+        let input = "bank"
+        print("Input: \(input)")
+        let output = Solution().areAlmostEqual(input, "kanb")
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func areAlmostEqual(_ s1: String, _ s2: String) -> Bool {
+        let hashMapS1 = hashMap(s1)
+        let hashMapS2 = hashMap(s2)
+
+        var areAlmostEqual = true
+
+        var hashMapDiff: [Character : Character] = [:]
+        for (key, value1) in hashMapS1 {
+            let value2 = hashMapS2[key]!
+
+            if value1 != value2 {
+                if hashMapDiff[value1] != nil {
+                    areAlmostEqual = false
+                    break
+                } else {
+                    hashMapDiff[value1] = value2
+                }
+            }
+        }
+
+        if areAlmostEqual {
+            let diffKeys = Array(hashMapDiff.keys)
+
+            if diffKeys.count == 0 { areAlmostEqual = true }
+            else if diffKeys.count == 2 {
+                let firstKey = diffKeys[0]
+                let secondKey = diffKeys[1]
+
+                let firstValue = hashMapDiff[firstKey]!
+                let secondValue = hashMapDiff[secondKey]!
+
+                if firstKey == secondValue && firstValue == secondKey {
+                    areAlmostEqual = true
+                } else {
+                    areAlmostEqual = false
+                }
+            } else {
+                areAlmostEqual = false
+            }
+        }
+
+        return areAlmostEqual
+    }
+
+    private func hashMap(_ string: String) -> [Int : Character] {
+        var hashMap: [Int : Character] = [:]
+
+        for index in 0..<string.count {
+            hashMap[index] = string[index]
+        }
+
+        return hashMap
+    }
+}
+
+private extension StringProtocol {
+    subscript(offset: Int) -> Character {
+        self[index(startIndex, offsetBy: offset)]
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -66,6 +66,7 @@ class ViewController: UIViewController {
         solve52()
         solve53()
         solve54()
+        solve55()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Data Structure &amp; Algorithms (Swift language)
 [![LeetCode: @crazymanish](https://img.shields.io/badge/LeetCode-@crazymanish-blue.svg?style=flat)](https://leetcode.com/crazymanish/)
 [![Twitter: @iammanishrathi](https://img.shields.io/badge/Twitter-@iammanishrathi-blue.svg?style=flat)](https://twitter.com/iammanishrathi)
 ------
-**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/071-days-green.svg?style=flat)
+**Consistency tracker:** ![![consistency days]](https://img.shields.io/badge/072-days-green.svg?style=flat)
 
 Data Structure Goals:
 - [x] Array
@@ -391,3 +391,6 @@ Day70:
 Day71:
 - [x] [LeetCode-1796. Second Largest Digit in a String](https://leetcode.com/problems/second-largest-digit-in-a-string/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge53.swift)
 - [x] [LeetCode-141. Linked List Cycle](https://leetcode.com/problems/linked-list-cycle/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge54.swift)
+
+Day72:
+- [x] [LeetCode-1790. Check if One String Swap Can Make Strings Equal](https://leetcode.com/problems/check-if-one-string-swap-can-make-strings-equal/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge55.swift)


### PR DESCRIPTION
 1790. Check if One String Swap Can Make Strings Equal
 https://leetcode.com/problems/check-if-one-string-swap-can-make-strings-equal/
 You are given two strings s1 and s2 of equal length. A string swap is an operation where you choose two indices in a string (not necessarily different) and swap the characters at these indices.

 Return true if it is possible to make both strings equal by performing at most one string swap on exactly one of the strings. Otherwise, return false.

 Example 1:
 Input: s1 = "bank", s2 = "kanb"
 Output: true
 Explanation: For example, swap the first character with the last character of s2 to make "bank".

 Example 2:
 Input: s1 = "attack", s2 = "defend"
 Output: false
 Explanation: It is impossible to make them equal with one string swap.

 Example 3:
 Input: s1 = "kelb", s2 = "kelb"
 Output: true
 Explanation: The two strings are already equal, so no string swap operation is required.