### PR TITLE
Day80: LeetCode-811. Subdomain Visit Count - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		13DCCC8E27F6EA2B006F89CB /* ViewController+Challenge69.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC8D27F6EA2B006F89CB /* ViewController+Challenge69.swift */; };
 		13DCCC9027F6EB69006F89CB /* ViewController+Challenge70.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC8F27F6EB69006F89CB /* ViewController+Challenge70.swift */; };
 		13DCCC9227F6EE0D006F89CB /* ViewController+Challenge71.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9127F6EE0D006F89CB /* ViewController+Challenge71.swift */; };
+		13DCCC9427F6EF17006F89CB /* ViewController+Challenge72.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9327F6EF17006F89CB /* ViewController+Challenge72.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -166,6 +167,7 @@
 		13DCCC8D27F6EA2B006F89CB /* ViewController+Challenge69.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge69.swift"; sourceTree = "<group>"; };
 		13DCCC8F27F6EB69006F89CB /* ViewController+Challenge70.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge70.swift"; sourceTree = "<group>"; };
 		13DCCC9127F6EE0D006F89CB /* ViewController+Challenge71.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge71.swift"; sourceTree = "<group>"; };
+		13DCCC9327F6EF17006F89CB /* ViewController+Challenge72.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge72.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -272,6 +274,7 @@
 				13DCCC8D27F6EA2B006F89CB /* ViewController+Challenge69.swift */,
 				13DCCC8F27F6EB69006F89CB /* ViewController+Challenge70.swift */,
 				13DCCC9127F6EE0D006F89CB /* ViewController+Challenge71.swift */,
+				13DCCC9327F6EF17006F89CB /* ViewController+Challenge72.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -416,6 +419,7 @@
 				13DCCC8227F445E9006F89CB /* ViewController+Challenge63.swift in Sources */,
 				136125A827EF63480081672D /* ViewController+Challenge8.swift in Sources */,
 				13DCCC6E27F35451006F89CB /* ViewController+Challenge53.swift in Sources */,
+				13DCCC9427F6EF17006F89CB /* ViewController+Challenge72.swift in Sources */,
 				136125AC27EF6E8B0081672D /* ViewController+Challenge10.swift in Sources */,
 				1361258827EE5DC80081672D /* SceneDelegate.swift in Sources */,
 				136125B827EFB0FE0081672D /* ViewController+Challenge16.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge72.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge72.swift
@@ -1,0 +1,75 @@
+//
+//  ViewController+Challenge72.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 01/04/2022.
+//
+
+import Foundation
+/*
+ 811. Subdomain Visit Count
+ https://leetcode.com/problems/subdomain-visit-count/
+ A website domain "discuss.leetcode.com" consists of various subdomains. At the top level, we have "com", at the next level, we have "leetcode.com" and at the lowest level, "discuss.leetcode.com". When we visit a domain like "discuss.leetcode.com", we will also visit the parent domains "leetcode.com" and "com" implicitly.
+ A count-paired domain is a domain that has one of the two formats "rep d1.d2.d3" or "rep d1.d2" where rep is the number of visits to the domain and d1.d2.d3 is the domain itself.
+ For example, "9001 discuss.leetcode.com" is a count-paired domain that indicates that discuss.leetcode.com was visited 9001 times.
+ Given an array of count-paired domains cpdomains, return an array of the count-paired domains of each subdomain in the input. You may return the answer in any order.
+
+ Example 1:
+ Input: cpdomains = ["9001 discuss.leetcode.com"]
+ Output: ["9001 leetcode.com","9001 discuss.leetcode.com","9001 com"]
+ Explanation: We only have one website domain: "discuss.leetcode.com".
+ As discussed above, the subdomain "leetcode.com" and "com" will also be visited. So they will all be visited 9001 times.
+
+ Example 2:
+ Input: cpdomains = ["900 google.mail.com", "50 yahoo.com", "1 intel.mail.com", "5 wiki.org"]
+ Output: ["901 mail.com","50 yahoo.com","900 google.mail.com","5 wiki.org","5 org","1 intel.mail.com","951 com"]
+ Explanation: We will visit "google.mail.com" 900 times, "yahoo.com" 50 times, "intel.mail.com" once and "wiki.org" 5 times.
+ For the subdomains, we will visit "mail.com" 900 + 1 = 901 times, "com" 900 + 50 + 1 = 951 times, and "org" 5 times.
+ */
+
+extension ViewController {
+    func solve72() {
+        print("Setting up Challenge72 input!")
+
+        let input = ["900 google.mail.com", "50 yahoo.com", "1 intel.mail.com", "5 wiki.org"]
+        print("Input: \(input)")
+        let output = Solution().subdomainVisits(input)
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func subdomainVisits(_ cpdomains: [String]) -> [String] {
+        var hashMap: [String : Int] = [:]
+
+        for cpdomain in cpdomains {
+            let cpdomainComponents = cpdomain.components(separatedBy: " ")
+            let visitedTimes = Int(cpdomainComponents[0])!
+            let domain = cpdomainComponents[1]
+            let subdomains = domain.components(separatedBy: ".")
+            let subdomainsCount = subdomains.count
+
+            for index in 0..<subdomainsCount {
+                var currentIndex = index
+                var subdomain = ""
+
+                while currentIndex < subdomainsCount {
+                    subdomain += "\(subdomains[currentIndex])."
+                    currentIndex += 1
+                }
+
+                subdomain.removeLast() // extra dot
+
+                let hashMapValue = hashMap[subdomain] ?? 0
+                hashMap[subdomain] = hashMapValue + visitedTimes
+            }
+        }
+
+        var output: [String] = []
+        for (key, value) in hashMap {
+            output.append("\(value) \(key)")
+        }
+
+        return output
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -83,5 +83,6 @@ class ViewController: UIViewController {
         solve69()
         solve70()
         solve71()
+        solve72()
     }
 }

--- a/README.md
+++ b/README.md
@@ -426,3 +426,4 @@ Day79:
 
 Day80:
 - [x] [LeetCode-890. Find and Replace Pattern](https://leetcode.com/problems/find-and-replace-pattern/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge71.swift)
+- [x] [LeetCode-811. Subdomain Visit Count](https://leetcode.com/problems/subdomain-visit-count/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge72.swift)


### PR DESCRIPTION
 811. Subdomain Visit Count
 https://leetcode.com/problems/subdomain-visit-count/
 A website domain "discuss.leetcode.com" consists of various subdomains. At the top level, we have "com", at the next level, we have "leetcode.com" and at the lowest level, "discuss.leetcode.com". When we visit a domain like "discuss.leetcode.com", we will also visit the parent domains "leetcode.com" and "com" implicitly.
 A count-paired domain is a domain that has one of the two formats "rep d1.d2.d3" or "rep d1.d2" where rep is the number of visits to the domain and d1.d2.d3 is the domain itself.
 For example, "9001 discuss.leetcode.com" is a count-paired domain that indicates that discuss.leetcode.com was visited 9001 times.
 Given an array of count-paired domains cpdomains, return an array of the count-paired domains of each subdomain in the input. You may return the answer in any order.

 Example 1:
 Input: cpdomains = ["9001 discuss.leetcode.com"]
 Output: ["9001 leetcode.com","9001 discuss.leetcode.com","9001 com"]
 Explanation: We only have one website domain: "discuss.leetcode.com".
 As discussed above, the subdomain "leetcode.com" and "com" will also be visited. So they will all be visited 9001 times.

 Example 2:
 Input: cpdomains = ["900 google.mail.com", "50 yahoo.com", "1 intel.mail.com", "5 wiki.org"]
 Output: ["901 mail.com","50 yahoo.com","900 google.mail.com","5 wiki.org","5 org","1 intel.mail.com","951 com"]
 Explanation: We will visit "google.mail.com" 900 times, "yahoo.com" 50 times, "intel.mail.com" once and "wiki.org" 5 times.
 For the subdomains, we will visit "mail.com" 900 + 1 = 901 times, "com" 900 + 50 + 1 = 951 times, and "org" 5 times.