### PR TITLE
Day82: LeetCode-2186. Minimum Number of Steps to Make Two Strings Anagram II - HashTable

### DIFF
--- a/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
+++ b/DataStructures/HashTable/HashTable.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		13DCCC9627F6F0C4006F89CB /* ViewController+Challenge73.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9527F6F0C4006F89CB /* ViewController+Challenge73.swift */; };
 		13DCCC9827F6F2E9006F89CB /* ViewController+Challenge74.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9727F6F2E9006F89CB /* ViewController+Challenge74.swift */; };
 		13DCCC9A27F6F402006F89CB /* ViewController+Challenge75.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9927F6F402006F89CB /* ViewController+Challenge75.swift */; };
+		13DCCC9C27F6F611006F89CB /* ViewController+Challenge76.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DCCC9B27F6F611006F89CB /* ViewController+Challenge76.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -174,6 +175,7 @@
 		13DCCC9527F6F0C4006F89CB /* ViewController+Challenge73.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge73.swift"; sourceTree = "<group>"; };
 		13DCCC9727F6F2E9006F89CB /* ViewController+Challenge74.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge74.swift"; sourceTree = "<group>"; };
 		13DCCC9927F6F402006F89CB /* ViewController+Challenge75.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge75.swift"; sourceTree = "<group>"; };
+		13DCCC9B27F6F611006F89CB /* ViewController+Challenge76.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Challenge76.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -284,6 +286,7 @@
 				13DCCC9527F6F0C4006F89CB /* ViewController+Challenge73.swift */,
 				13DCCC9727F6F2E9006F89CB /* ViewController+Challenge74.swift */,
 				13DCCC9927F6F402006F89CB /* ViewController+Challenge75.swift */,
+				13DCCC9B27F6F611006F89CB /* ViewController+Challenge76.swift */,
 				1361258B27EE5DC80081672D /* Main.storyboard */,
 				1361258E27EE5DCC0081672D /* Assets.xcassets */,
 				1361259027EE5DCC0081672D /* LaunchScreen.storyboard */,
@@ -376,6 +379,7 @@
 				13DCCC8027F44452006F89CB /* ViewController+Challenge62.swift in Sources */,
 				136125F027F215990081672D /* ViewController+Challenge44.swift in Sources */,
 				13DCCC6627F34DB5006F89CB /* ViewController+Challenge49.swift in Sources */,
+				13DCCC9C27F6F611006F89CB /* ViewController+Challenge76.swift in Sources */,
 				136125B627EFA92A0081672D /* ViewController+Challenge15.swift in Sources */,
 				136125A627EF5ED30081672D /* ViewController+Challenge7.swift in Sources */,
 				13DCCC9027F6EB69006F89CB /* ViewController+Challenge70.swift in Sources */,

--- a/DataStructures/HashTable/HashTable/ViewController+Challenge76.swift
+++ b/DataStructures/HashTable/HashTable/ViewController+Challenge76.swift
@@ -1,0 +1,77 @@
+//
+//  ViewController+Challenge76.swift
+//  HashTable
+//
+//  Created by Manish Rathi on 01/04/2022.
+//
+
+import Foundation
+/*
+ 2186. Minimum Number of Steps to Make Two Strings Anagram II
+ https://leetcode.com/problems/minimum-number-of-steps-to-make-two-strings-anagram-ii/
+ You are given two strings s and t. In one step, you can append any character to either s or t.
+ Return the minimum number of steps to make s and t anagrams of each other.
+ An anagram of a string is a string that contains the same characters with a different (or the same) ordering.
+
+ Example 1:
+ Input: s = "leetcode", t = "coats"
+ Output: 7
+ Explanation:
+ - In 2 steps, we can append the letters in "as" onto s = "leetcode", forming s = "leetcodeas".
+ - In 5 steps, we can append the letters in "leede" onto t = "coats", forming t = "coatsleede".
+ "leetcodeas" and "coatsleede" are now anagrams of each other.
+ We used a total of 2 + 5 = 7 steps.
+ It can be shown that there is no way to make them anagrams of each other with less than 7 steps.
+
+ Example 2:
+ Input: s = "night", t = "thing"
+ Output: 0
+ Explanation: The given strings are already anagrams of each other. Thus, we do not need any further steps.
+ */
+
+extension ViewController {
+    func solve76() {
+        print("Setting up Challenge76 input!")
+
+        let input = "leetcode"
+        print("Input: \(input)")
+        let output = Solution().minSteps(input, "coats")
+        print("Output: \(output)")
+    }
+}
+
+private class Solution {
+    func minSteps(_ s: String, _ t: String) -> Int {
+        let hashMapS = hashMap(s)
+        let hashMapT = hashMap(t)
+
+        var output = 0
+        for (key, valueS) in hashMapS {
+            let valueT = hashMapT[key] ?? 0
+            let minStepsRequired = max(valueS - valueT, 0)
+
+            output += minStepsRequired
+        }
+
+        for (key, valueT) in hashMapT {
+            let valueS = hashMapS[key] ?? 0
+            let minStepsRequired = max(valueT - valueS, 0)
+
+            output += minStepsRequired
+        }
+
+        return output
+    }
+
+    private func hashMap(_ string: String) -> [Character : Int] {
+        typealias Frequency = Int
+        var hashMap: [Character : Frequency] = [:]
+
+        for char in string {
+            let hashMapValue = hashMap[char] ?? 0
+            hashMap[char] = hashMapValue + 1
+        }
+
+        return hashMap
+    }
+}

--- a/DataStructures/HashTable/HashTable/ViewController.swift
+++ b/DataStructures/HashTable/HashTable/ViewController.swift
@@ -87,5 +87,6 @@ class ViewController: UIViewController {
         solve73()
         solve74()
         solve75()
+        solve76()
     }
 }

--- a/README.md
+++ b/README.md
@@ -434,3 +434,4 @@ Day81:
 
 Day82:
 - [x] [LeetCode-1396. Design Underground System](https://leetcode.com/problems/design-underground-system/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge75.swift)
+- [x] [LeetCode-2186. Minimum Number of Steps to Make Two Strings Anagram II](https://leetcode.com/problems/minimum-number-of-steps-to-make-two-strings-anagram-ii/) - [**Solution**](https://github.com/crazymanish/dsa/blob/main/DataStructures/HashTable/HashTable/ViewController%2BChallenge76.swift)


### PR DESCRIPTION
 2186. Minimum Number of Steps to Make Two Strings Anagram II
 https://leetcode.com/problems/minimum-number-of-steps-to-make-two-strings-anagram-ii/
 You are given two strings s and t. In one step, you can append any character to either s or t.
 Return the minimum number of steps to make s and t anagrams of each other.
 An anagram of a string is a string that contains the same characters with a different (or the same) ordering.

 Example 1:
 Input: s = "leetcode", t = "coats"
 Output: 7
 Explanation:
 - In 2 steps, we can append the letters in "as" onto s = "leetcode", forming s = "leetcodeas".
 - In 5 steps, we can append the letters in "leede" onto t = "coats", forming t = "coatsleede".
 "leetcodeas" and "coatsleede" are now anagrams of each other.
 We used a total of 2 + 5 = 7 steps.
 It can be shown that there is no way to make them anagrams of each other with less than 7 steps.

 Example 2:
 Input: s = "night", t = "thing"
 Output: 0
 Explanation: The given strings are already anagrams of each other. Thus, we do not need any further steps.